### PR TITLE
Feat/#24 reservation-service 예약 선점 kafka 컨슈머 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,39 @@ services:
       - "6379:6379"
     restart: always
 
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    platform: linux/amd64
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: wurstmeister/kafka:latest
+    platform: linux/amd64
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:29092,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_READONLY: "false"
+
 volumes:
   mysql-data:
-

--- a/reservation-service/build.gradle
+++ b/reservation-service/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/config/ReservationKafkaConfig.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/config/ReservationKafkaConfig.java
@@ -1,0 +1,65 @@
+package com.oneul_tanda.reservation_service.config;
+
+import com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event.ReservationHeldEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Kafka 컨슈머 설정을 위한 Spring 설정 클래스
+ */
+@EnableKafka
+@Configuration
+public class ReservationKafkaConfig {
+
+
+    /**
+     * ReservationHeldEvent 타입의 Kafka ConsumerFactory 빈 정의
+     * - Kafka 컨슈머 인스턴스를 생성하는 팩토리
+     * - 메시지의 key는 String, value는 ReservationHeldEvent
+     * - JsonDeserializer를 통해 ReservationHeldEvent 역직렬화 처리
+     */
+    @Bean
+    public ConsumerFactory<String, ReservationHeldEvent> reservationHeldConsumerFactory() {
+
+        JsonDeserializer<ReservationHeldEvent> jsonDeserializer = new JsonDeserializer<>(ReservationHeldEvent.class);
+        jsonDeserializer.addTrustedPackages("com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event");
+
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(
+                configProps,
+                new StringDeserializer(),
+                jsonDeserializer
+        );
+    }
+
+
+    /**
+     * ReservationHeldEvent 타입의 Kafka 리스너 컨테이너 팩토리 빈 정의
+     * - @KafkaListener 메서드를 실행할 컨테이너를 생성
+     * - 내부적으로 reservationHeldConsumerFactory를 사용하여 컨슈머 생성
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ReservationHeldEvent> reservationHeldListenerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ReservationHeldEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(reservationHeldConsumerFactory());
+        return factory;
+    }
+
+
+
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommand.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommand.java
@@ -1,0 +1,47 @@
+package com.oneul_tanda.reservation_service.reservation.application.command;
+
+import com.oneul_tanda.reservation_service.passenger.domain.entity.Gender;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDto;
+
+import java.util.List;
+
+import java.util.UUID;
+
+public record ConfirmReservationCommand(
+        UUID reservationId,
+        List<ConfirmTicketCommand> tickets
+) {
+    public static ConfirmReservationCommand of(UUID reservationId, ConfirmReservationRequestDto dto) {
+        return new ConfirmReservationCommand(
+                reservationId,
+                dto.tickets().stream()
+                        .map(ConfirmTicketCommand::from)
+                        .toList()
+        );
+    }
+
+
+
+    public record ConfirmTicketCommand(
+            UUID ticketId,
+            ConfirmPassengerCommand passenger
+    ) {
+        public static ConfirmTicketCommand from(ConfirmReservationRequestDto.ConfirmTicketDto dto) {
+            return new ConfirmTicketCommand(dto.ticketId(), ConfirmPassengerCommand.from(dto.passenger()));
+        }
+    }
+
+
+
+    public record ConfirmPassengerCommand(
+            String birth,
+            Gender gender,
+            String passportNumber
+    ) {
+        public static ConfirmPassengerCommand from(ConfirmReservationRequestDto.ConfirmPassengerDto dto) {
+            return new ConfirmPassengerCommand(dto.birth(), dto.gender(), dto.passportNumber());
+        }
+    }
+}
+
+

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/CreateHoldReservationCommand.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/CreateHoldReservationCommand.java
@@ -1,0 +1,21 @@
+package com.oneul_tanda.reservation_service.reservation.application.command;
+
+import java.util.UUID;
+
+public record CreateHoldReservationCommand(
+        UUID flightId,
+        Long userId,
+        int seatCount
+) {
+    public static CreateHoldReservationCommand of(
+            UUID flightId,
+            Long userId,
+            int seatCount
+    ) {
+        return new CreateHoldReservationCommand(flightId, userId, seatCount);
+    }
+}
+
+
+
+

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
@@ -1,6 +1,8 @@
 package com.oneul_tanda.reservation_service.reservation.application.service;
 
+import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.CreateReservationRequestDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
 import org.springframework.data.domain.Page;
@@ -9,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 import java.util.UUID;
 
 public interface ReservationService {
+
+    CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command);
 
     CreateReservationResponseDto createReservation(CreateReservationRequestDto requestDto);
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
@@ -1,9 +1,11 @@
 package com.oneul_tanda.reservation_service.reservation.application.service;
 
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.CreateReservationRequestDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,4 +21,6 @@ public interface ReservationService {
     ReadReservationResponseDto readReservation(UUID reservationId);
 
     Page<ReadReservationResponseDto> readAllReservation(Pageable pageable);
+
+    ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand command);
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
@@ -1,6 +1,7 @@
 package com.oneul_tanda.reservation_service.reservation.application.service;
 
 import com.oneul_tanda.reservation_service.passenger.domain.entity.Passenger;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.domain.entity.Reservation;
 import com.oneul_tanda.reservation_service.reservation.domain.repository.ReservationRepository;
@@ -8,6 +9,7 @@ import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
 import com.oneul_tanda.reservation_service.ticket.domain.entity.SeatClass;
 import com.oneul_tanda.reservation_service.ticket.domain.entity.Ticket;
 import lombok.RequiredArgsConstructor;
@@ -125,5 +127,46 @@ public class ReservationServiceImpl implements ReservationService {
     public Page<ReadReservationResponseDto> readAllReservation(Pageable pageable) {
         return reservationRepository.findAll(pageable)
                 .map(ReadReservationResponseDto::from);
+    }
+
+
+
+
+    /**
+     * 예약 확정 (예약 수정)
+     */
+    @Override
+    public ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand command) {
+        // 1. 예약 조회 (예약 + 티켓)
+        Reservation reservation = reservationRepository.findById(command.reservationId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 예약을 찾을 수 없습니다."));
+
+
+        // 2. 티켓 확정 (탑승객 정보 매핑)
+        for (ConfirmReservationCommand.ConfirmTicketCommand ticketCommand : command.tickets()) {
+            // 2-1. 해당 ticketId를 가진 티켓 찾기
+            Ticket ticket = reservation.getTicketList().stream()
+                    .filter(t -> t.getId().equals(ticketCommand.ticketId()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("해당 티켓을 찾을 수 없습니다."));
+
+            // 2-2. 탑승객 생성 및 티켓에 확정 처리
+            Passenger passenger = Passenger.createPassenger(
+                    ticketCommand.passenger().birth(),
+                    ticketCommand.passenger().gender(),
+                    ticketCommand.passenger().passportNumber()
+            );
+
+            ticket.confirmTicket(passenger);
+        }
+
+        // 3. 예약 상태를 확정으로 변경
+        reservation.confirmReservation();
+
+        // 4. 변경사항 저장 (티켓 및 탑승객 포함)
+        reservationRepository.save(reservation);
+
+        // 5. 응답 반환
+        return ConfirmReservationResponseDto.from(reservation);
     }
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
@@ -1,11 +1,14 @@
 package com.oneul_tanda.reservation_service.reservation.application.service;
 
 import com.oneul_tanda.reservation_service.passenger.domain.entity.Passenger;
+import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.domain.entity.Reservation;
 import com.oneul_tanda.reservation_service.reservation.domain.repository.ReservationRepository;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.CreateReservationRequestDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
+import com.oneul_tanda.reservation_service.ticket.domain.entity.SeatClass;
 import com.oneul_tanda.reservation_service.ticket.domain.entity.Ticket;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -25,7 +29,7 @@ public class ReservationServiceImpl implements ReservationService {
     private final ReservationRepository reservationRepository;
 
     /**
-     * 에약 생성
+     * 예약 생성
      */
     @Override
     public CreateReservationResponseDto createReservation(CreateReservationRequestDto requestDto) {
@@ -60,6 +64,40 @@ public class ReservationServiceImpl implements ReservationService {
         );
 
         return CreateReservationResponseDto.from(reservationRepository.save(reservation));
+    }
+
+
+
+    /**
+     * 에약 임시 생성
+     */
+    @Override
+    public CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command) {
+
+        // TODO FeignClient 항공편 조회
+
+        // 티켓 임시 생성
+        List<Ticket> ticketList = new ArrayList<>();
+
+        for (int i = 0; i < command.seatCount(); i++) {
+            Ticket ticket = Ticket.createTicketWithoutPassenger(
+                    command.flightId(),
+                    // TODO 임시 값 설정, 항공편 조회에서 데이터 획득 고려
+                    SeatClass.ECONOMY,
+                    BigDecimal.valueOf(10000)
+            );
+
+            ticketList.add(ticket);
+        }
+
+
+        // 예약 임시 생성
+        Reservation reservation = Reservation.createHoldReservation(
+                command.userId(),
+                ticketList
+        );
+
+        return CreateHoldReservationResponseDto.from(reservationRepository.save(reservation));
     }
 
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/domain/entity/Reservation.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/domain/entity/Reservation.java
@@ -86,4 +86,13 @@ public class Reservation {
         ticket.associateTicket(this);  // 티켓에서도 해당 예약 정보 설정, setter 대신 associateTicket 메서드 사용
     }
 
+
+
+
+    /**
+     * 예약 확정
+     */
+    public void confirmReservation() {
+        this.status = ReservationStatus.RESERVED;
+    }
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/domain/entity/Reservation.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/domain/entity/Reservation.java
@@ -58,6 +58,28 @@ public class Reservation {
     }
 
 
+
+    /**
+     * 예약 임시 생성
+     */
+    public static Reservation createHoldReservation(Long userId, List<Ticket> ticketList) {
+
+        Reservation reservation = Reservation.builder()
+                .userId(userId)
+                .ticketList(new ArrayList<>())
+                .totalPrice(BigDecimal.ZERO) // 임시 0원 설정
+                .status(ReservationStatus.PENDING)
+                .build();
+
+        // 예약과(Reservation)과 티켓(Ticket) 간의 양방향 연관 관계 설정
+        for (Ticket ticket : ticketList) {
+            reservation.addTicket(ticket);
+        }
+
+        return reservation;
+    }
+
+
     // 연관 관계 설정 메서드
     public void addTicket(Ticket ticket) {
         this.ticketList.add(ticket);   // 예약 티켓 리스트에 티켓 추가

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/ReservationHeldEventConsumer.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/ReservationHeldEventConsumer.java
@@ -1,0 +1,37 @@
+package com.oneul_tanda.reservation_service.reservation.infrastructure.kafka;
+
+import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.service.ReservationService;
+import com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event.ReservationHeldEvent;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationHeldEventConsumer {
+
+    private final ReservationService reservationService;
+
+
+    @KafkaListener(
+            topics = "reservation-held",
+            groupId = "reservation-service",
+            containerFactory = "reservationHeldListenerFactory"
+    )
+    public CreateHoldReservationResponseDto consumeReservationHeldForReservation(ReservationHeldEvent event) {
+
+        var data = event.data();
+
+        CreateHoldReservationCommand command = CreateHoldReservationCommand.of(
+                data.flightId(),
+                data.userId(),
+                data.seatCount()
+        );
+
+        // 예약 임시 생성(사용자가 추후 예약정보 입력하여 예약 완료)
+        return reservationService.createHoldReservation(command);
+    }
+
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/event/ReservationHeldEvent.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/event/ReservationHeldEvent.java
@@ -1,0 +1,20 @@
+package com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+public record ReservationHeldEvent(
+        String eventId,                    // 대상: 이벤트 고유 ID or 이벤트 대상 ID
+        String eventType,                  // 행위: 이벤트 타입    (ex: 예약 선점)
+        LocalDateTime occurrenceDateTime,  // 시간: 행위 발생 시각  (ex: 선점이 일어난 시간)
+        Data data                          // 정보: 행위와 관련된 정보
+) {
+
+    public record Data(
+            UUID flightId,
+            Long userId,
+            int seatCount
+    ) {}
+}
+

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
@@ -1,8 +1,11 @@
 package com.oneul_tanda.reservation_service.reservation.presentation;
 
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.service.ReservationService;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.CreateReservationRequestDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -33,6 +36,16 @@ public class ReservationController {
     @PostMapping
     public ResponseEntity<CreateReservationResponseDto> createReservation(@RequestBody CreateReservationRequestDto requestDto) {
         return ResponseEntity.ok(reservationService.createReservation(requestDto));
+    }
+
+
+    /**
+     * 에약 확정 (예약 수정)
+     */
+    @PutMapping("/{reservationId}/confirm")
+    public ResponseEntity<ConfirmReservationResponseDto> confirmReservation(@PathVariable UUID reservationId,
+                                                                            @RequestBody ConfirmReservationRequestDto requestDto) {
+        return ResponseEntity.ok(reservationService.confirmReservation(ConfirmReservationCommand.of(reservationId, requestDto)));
     }
 
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/request/update/ConfirmReservationRequestDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/request/update/ConfirmReservationRequestDto.java
@@ -1,0 +1,23 @@
+package com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update;
+
+import com.oneul_tanda.reservation_service.passenger.domain.entity.Gender;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ConfirmReservationRequestDto(
+        List<ConfirmTicketDto> tickets
+) {
+
+    public record ConfirmTicketDto(
+            UUID ticketId,
+            ConfirmPassengerDto passenger
+    ) {}
+
+    public record ConfirmPassengerDto(
+            String birth,
+            Gender gender,
+            String passportNumber
+    ) {}
+}
+

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/create/CreateHoldReservationResponseDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/create/CreateHoldReservationResponseDto.java
@@ -1,0 +1,33 @@
+package com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create;
+
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Reservation;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.ReservationStatus;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Builder
+public record CreateHoldReservationResponseDto(
+        UUID reservationId,
+        Long userId,
+        BigDecimal totalPrice,
+        ReservationStatus status,
+        List<CreateHoldTicketResponseDto> tickets
+) {
+
+    // Entity -> DTO 변환 메서드
+    public static CreateHoldReservationResponseDto from(Reservation reservation) {
+        return CreateHoldReservationResponseDto.builder()
+                .reservationId(reservation.getId())
+                .userId(reservation.getUserId())
+                .totalPrice(reservation.getTotalPrice())
+                .status(reservation.getStatus())
+                .tickets(reservation.getTicketList().stream()
+                        .map(CreateHoldTicketResponseDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/create/CreateHoldTicketResponseDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/create/CreateHoldTicketResponseDto.java
@@ -1,0 +1,27 @@
+package com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create;
+
+import com.oneul_tanda.reservation_service.ticket.domain.entity.Ticket;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Builder
+public record CreateHoldTicketResponseDto(
+        UUID ticketId,
+        UUID flightId,
+        String seatClass,
+        BigDecimal unitPrice
+) {
+
+    // Entity -> DTO 변환 메서드
+    public static CreateHoldTicketResponseDto from(Ticket ticket) {
+        return CreateHoldTicketResponseDto.builder()
+                .ticketId(ticket.getId())
+                .flightId(ticket.getFlightId())
+                .seatClass(ticket.getSeatClass().name())
+                .unitPrice(ticket.getUnitPrice())
+                .build();
+    }
+}
+

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/update/ConfirmPassengerResponseDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/update/ConfirmPassengerResponseDto.java
@@ -1,0 +1,24 @@
+package com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update;
+
+import com.oneul_tanda.reservation_service.passenger.domain.entity.Gender;
+import com.oneul_tanda.reservation_service.passenger.domain.entity.Passenger;
+
+import java.util.UUID;
+
+public record ConfirmPassengerResponseDto(
+        UUID passengerId,
+        String birth,
+        Gender gender,
+        String passportNumber
+) {
+
+    // Entity -> DTO 변환 메서드
+    public static ConfirmPassengerResponseDto from(Passenger passenger) {
+        return new ConfirmPassengerResponseDto(
+                passenger.getId(),
+                passenger.getBirth(),
+                passenger.getGender(),
+                passenger.getPassportNumber()
+        );
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/update/ConfirmReservationResponseDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/update/ConfirmReservationResponseDto.java
@@ -1,0 +1,37 @@
+package com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update;
+
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Reservation;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.ReservationStatus;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Builder
+public record ConfirmReservationResponseDto(
+        UUID reservationId,
+        Long userId,
+        BigDecimal totalPrice,
+        ReservationStatus status,
+        List<ConfirmTicketResponseDto> tickets
+) {
+
+    // Entity -> DTO 변환 메서드
+    public static ConfirmReservationResponseDto from(Reservation reservation) {
+        return ConfirmReservationResponseDto.builder()
+                .reservationId(reservation.getId())
+                .userId(reservation.getUserId())
+                .totalPrice(reservation.getTotalPrice())
+                .status(reservation.getStatus())
+                .tickets(reservation.getTicketList().stream()
+                        .map(ConfirmTicketResponseDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+
+
+
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/update/ConfirmTicketResponseDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/response/update/ConfirmTicketResponseDto.java
@@ -1,0 +1,29 @@
+package com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update;
+
+import com.oneul_tanda.reservation_service.ticket.domain.entity.Ticket;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Builder
+public record ConfirmTicketResponseDto(
+        UUID ticketId,
+        UUID flightId,
+        String seatClass,
+        BigDecimal unitPrice,
+        ConfirmPassengerResponseDto passenger
+) {
+
+    // Entity -> DTO 변환 메서드
+    public static ConfirmTicketResponseDto from(Ticket ticket) {
+        return ConfirmTicketResponseDto.builder()
+                .ticketId(ticket.getId())
+                .flightId(ticket.getFlightId())
+                .seatClass(ticket.getSeatClass().name())
+                .unitPrice(ticket.getUnitPrice())
+                .passenger(ConfirmPassengerResponseDto.from(ticket.getPassenger()))
+                .build();
+    }
+}
+

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/ticket/domain/entity/Ticket.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/ticket/domain/entity/Ticket.java
@@ -37,7 +37,7 @@ public class Ticket {
     private Reservation reservation;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "passenger_id", nullable = false)
+    @JoinColumn(name = "passenger_id")
     private Passenger passenger;
 
 
@@ -47,6 +47,20 @@ public class Ticket {
     public static Ticket createTicket(Passenger passenger, UUID flightId, SeatClass seatClass, BigDecimal unitPrice) {
         return Ticket.builder()
                 .passenger(passenger)
+                .flightId(flightId)
+                .seatClass(seatClass)
+                .unitPrice(unitPrice)
+                .build();
+    }
+
+
+
+
+    /**
+     * 티켓 임시 생성
+     */
+    public static Ticket createTicketWithoutPassenger(UUID flightId, SeatClass seatClass, BigDecimal unitPrice) {
+        return Ticket.builder()
                 .flightId(flightId)
                 .seatClass(seatClass)
                 .unitPrice(unitPrice)

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/ticket/domain/entity/Ticket.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/ticket/domain/entity/Ticket.java
@@ -73,4 +73,15 @@ public class Ticket {
         this.reservation = reservation; // 티켓이 예약을 참조하도록 설정
     }
 
+
+
+
+    /**
+     * 티켓 확정
+     */
+    public void confirmTicket(Passenger passenger) {
+        this.passenger = passenger;
+    }
+
+
 }

--- a/reservation-service/src/main/resources/application.yml
+++ b/reservation-service/src/main/resources/application.yml
@@ -24,6 +24,13 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
 
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+
 server:
   port: 19095
 

--- a/reservation-service/src/test/http/reservation-service.http
+++ b/reservation-service/src/test/http/reservation-service.http
@@ -44,3 +44,30 @@ Content-Type: application/json
 ### 예약 목록 조회 - 1페이지, 5개씩 조회
 GET http://localhost:19095/api/v1/reservations?page=1&size=5
 Content-Type: application/json
+
+
+
+### 예약 확정(예약 수정)
+PUT http://localhost:19095/api/v1/reservations/c8b4c5e1-4668-4055-bd2c-b0a6b2d18d1a/confirm
+Content-Type: application/json
+
+{
+  "tickets": [
+    {
+      "ticketId": "a87e3f99-c125-4155-8a51-2dc367af8e46",
+      "passenger": {
+        "birth": "1990-01-01",
+        "gender": "MALE",
+        "passportNumber": "P12345678"
+      }
+    },
+    {
+      "ticketId": "d5f61238-aef8-4d35-8d5f-bc4b130e4297",
+      "passenger": {
+        "birth": "1995-06-10",
+        "gender": "FEMALE",
+        "passportNumber": "P87654321"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 💡 이슈
resolve #{24}

## 🤩 개요
- 예약 선점 (티켓팅 성공)에 대한 kafka 컨슈머 구현

## 🧑‍💻 작업 사항
- [kafka 및 컨슈머 설정]
- [kafka 컨슈머 및 이벤트(메세지) 추가]
- [dto 및 command 추가]
- [예약 임시 생성 기능 추가]
- [예약 확정(예약 수정) api 및 dto 추가]
- [예약 확정(예약 수정) 기능 추가]
- [예약 확정(예약 수정) HTTP 테스트 추가]

## 📖 참고 사항

- 예상 시나리오:
사용자:특가 항공권 예매 요청 →  예약 대기열 서비스: 좌석 선점 처리 →  좌석 선점 성공 → 예약 대기열 서비스: Kafka 예약 선점 성공 이벤트 발행 →  예약 서비스: Kafka Consumer 수신 → 예약 서비스:임시 예약 생성 -> 예약 서비스: 후 에 예약 확정 진행

- UI for Apache Kafka에서 테스트 데이터 생성 후 컨슈머 테스트 완료하였습니다.
 프로듀서 테스트 데이터:
 {
  "eventId": "123e4567-e89b-12d3-a456-426614174000",
  "eventType": "ReservationHeld",
  "eventTime": "2025-04-12T21:00:00",
  "data": {
    "flightId": "c7a43230-7bcd-11ee-b962-0242ac120002",
    "userId": "9b7f421f-47b0-47f5-aa5c-8f489697a57d",
    "seatCount": 2
  }
}


