### PR TITLE
Feat/#83 grafana CPU 사용률 알림 규칙 추가

### DIFF
--- a/grafana/provisioning/alerting/oneltanda-contact-points.yaml
+++ b/grafana/provisioning/alerting/oneltanda-contact-points.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: slack alert
+    editable: true
+    receivers:
+      - uid: slack-uid
+        type: slack
+        settings:
+          url: https://hooks.slack.com/services/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
+        disableResolveMessage: false

--- a/grafana/provisioning/alerting/oneltanda.yaml
+++ b/grafana/provisioning/alerting/oneltanda.yaml
@@ -1,60 +1,163 @@
 apiVersion: 1
 groups:
-    - orgId: 1
-      name: oneltanda
-      folder: oneltanda
-      interval: 1m
-      rules:
-        - uid: cej5ocua4giyoa
-          title: Up alert
-          condition: C
-          data:
-            - refId: A
-              relativeTimeRange:
-                from: 600
-                to: 0
-              datasourceUid: aej5j0p9ukphcc
-              model:
-                disableTextWrap: false
-                editorMode: builder
-                expr: up{job="spring-boot"}
-                fullMetaSearch: false
-                includeNullMetadata: true
-                instant: true
-                intervalMs: 1000
-                legendFormat: __auto
-                maxDataPoints: 43200
-                range: false
-                refId: A
-                useBackend: false
-            - refId: C
-              datasourceUid: __expr__
-              model:
-                conditions:
-                    - evaluator:
-                        params:
-                            - 1
-                        type: lt
-                      operator:
-                        type: and
-                      query:
-                        params:
-                            - C
-                      reducer:
-                        params: []
-                        type: last
-                      type: query
-                datasource:
-                    type: __expr__
-                    uid: __expr__
-                expression: A
-                intervalMs: 1000
-                maxDataPoints: 43200
-                refId: C
-                type: threshold
-          noDataState: NoData
-          execErrState: Error
-          for: 1m
-          isPaused: false
-          notification_settings:
-            receiver: slack alert
+  - orgId: 1
+    name: cpu
+    folder: oneltanda
+    interval: 1m
+    rules:
+      - uid: fejt47a1zv7r4e
+        title: CPU Used 50% alert
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: aej5j0p9ukphcc
+            model:
+              editorMode: code
+              expr: 100 * process_cpu_usage{instance=~"host\\.docker\\.internal:19096|host\\.docker\\.internal:19095",job="spring-boot"}
+              instant: true
+              intervalMs: 1000
+              legendFormat: __auto
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.5
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        isPaused: false
+        notification_settings:
+          receiver: slack alert
+      - uid: eejt4r89gcvswb
+        title: CPU Used 70% alert
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: aej5j0p9ukphcc
+            model:
+              editorMode: code
+              expr: 100 * process_cpu_usage{instance=~"host\\.docker\\.internal:19096|host\\.docker\\.internal:19095",job="spring-boot"}
+              instant: true
+              intervalMs: 1000
+              legendFormat: __auto
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.7
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        isPaused: false
+        notification_settings:
+          receiver: slack alert
+  - orgId: 1
+    name: oneltanda
+    folder: oneltanda
+    interval: 1m
+    rules:
+      - uid: cej5ocua4giyoa
+        title: Up alert
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: aej5j0p9ukphcc
+            model:
+              disableTextWrap: false
+              editorMode: builder
+              expr: up{job="spring-boot"}
+              fullMetaSearch: false
+              includeNullMetadata: true
+              instant: true
+              intervalMs: 1000
+              legendFormat: __auto
+              maxDataPoints: 43200
+              range: false
+              refId: A
+              useBackend: false
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 1
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: ""
+        panelId: 0
+        noDataState: NoData
+        execErrState: Error
+        for: 1m
+        isPaused: false
+        notification_settings:
+          receiver: slack alert

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,5 +1,9 @@
+apiVersion: 1
+
 datasources:
   - name: prometheus
     type: prometheus
+    access: proxy
+    uid: aej5j0p9ukphcc
     url: http://prometheus:9090
     isDefault: true


### PR DESCRIPTION
## 💡 이슈
resolve #{83}

## 🤩 개요
- grafana CPU 사용률 알림 규칙 추가


## 🧑‍💻 작업 사항
-  각 인스턴스별 CPU 사용률이 50%를 초과하면 Slack으로 경고 알림 전송
-  각 인스턴스별 CPU 사용률이 70%를 초과하면 추가적인 경고 알림 전송
-  대상 인스턴스: 19095, 19096
-  알림은 인스턴스별로 개별 평가되며, 초과한 인스턴스 정보가 메시지에 포함됨

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
