### PR TITLE
Feat/#79 flight-service user validate 추가

### DIFF
--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airline/AirlineExternalService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airline/AirlineExternalService.java
@@ -23,7 +23,9 @@ public class AirlineExternalService {
     private final AirlineRepository airlineRepository;
 
     // 실시간 항공사 정보 조회
-    public List<AirlineSearchResponse> searchAirlines(String keyword) throws Exception {
+    public List<AirlineSearchResponse> searchAirlines(String keyword, String userRole) throws Exception {
+        validateUserRole(userRole);
+
         Airline[] amadeusAirlines = amadeus.referenceData.airlines
                 .get(Params.with("airlineCodes", keyword));
 
@@ -35,7 +37,9 @@ public class AirlineExternalService {
     }
 
     // 실시간 항공사 정보 조회 및 DB 저장
-    public List<AirlineResponse> searchAndSaveAirlines(String keyword) throws Exception {
+    public List<AirlineResponse> searchAndSaveAirlines(String keyword, String userRole) throws Exception {
+        validateUserRole(userRole);
+
         Airline[] amadeusAirlines = amadeus.referenceData.airlines
                 .get(Params.with("airlineCodes", keyword));
 
@@ -56,4 +60,9 @@ public class AirlineExternalService {
                 .toList();
     }
 
+    private void validateUserRole(String userRole) {
+        if(userRole.equals("CUSTOMER")) {
+            throw new IllegalArgumentException("Access denied");
+        }
+    }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airline/AirlineService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airline/AirlineService.java
@@ -23,14 +23,17 @@ public class AirlineService {
     private final AirlineRepository airlineRepository;
 
     @Cacheable(value = "airlines", key = "#airlineId")
-    public AirlineResponse getAirline(UUID airlineId) {
-        AirlineEntity airline = airlineRepository.findById(airlineId)
-                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
+    public AirlineResponse getAirline(UUID airlineId, String userRole) {
+        validateUserRole(userRole);
+
+        AirlineEntity airline = getAirlineById(airlineId);
 
         return AirlineResponse.from(airline);
     }
 
-    public Page<AirlineResponse> searchAirlines(String code, String name, Pageable pageable) {
+    public Page<AirlineResponse> searchAirlines(String code, String name, Pageable pageable, String userRole) {
+        validateUserRole(userRole);
+
         Pageable adjusted = PagingUtil.adjustPageable(pageable);
         Page<AirlineEntity> airlines = airlineRepository.findByCodeAndName(code, name, adjusted);
 
@@ -39,44 +42,64 @@ public class AirlineService {
 
     @Transactional
     @CacheEvict(value = "airlines", allEntries = true) // 캐시 무효화
-    public AirlineResponse createAirline(CreateAirlineCommand airlineCommand) {
+    public AirlineResponse createAirline(CreateAirlineCommand airlineCommand, UUID userId, String userRole) {
+        validateUserRole(userRole);
 
-        if (airlineRepository.findByCode(airlineCommand.getCode()).isPresent()) {
-            throw new IllegalArgumentException("Airline code " + airlineCommand.getCode() + " already exists");
-        }
+        getAirlineByCode(airlineCommand);
+
         AirlineEntity airline = AirlineEntity.from(
                 airlineCommand.getCode(),
                 airlineCommand.getName()
         );
+
         airlineRepository.save(airline);
+        airline.updateCreationInfo(userId);
 
         return AirlineResponse.from(airline);
     }
 
     @Transactional
     @CacheEvict(value = "airlines", allEntries = true) // 캐시 무효화
-    public AirlineResponse updateAirline(UpdateAirlineCommand airlineCommand) {
+    public AirlineResponse updateAirline(UpdateAirlineCommand airlineCommand, UUID userId, String userRole) {
+        validateUserRole(userRole);
 
-        AirlineEntity airline = airlineRepository.findById(airlineCommand.getAirlineId())
-                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
+        AirlineEntity airline = getAirlineById(airlineCommand.getAirlineId());
 
         airline.updateOf(
                 airlineCommand.getCode(),
                 airlineCommand.getName()
         );
 
-//        airline.updateModificationInfo();
+        airline.updateModificationInfo(userId);
 
         return AirlineResponse.from(airline);
     }
 
     @Transactional
     @CacheEvict(value = "airlines", allEntries = true) // 캐시 무효화
-    public void deleteAirline(UUID airlineId) {
+    public void deleteAirline(UUID airlineId, UUID userId, String userRole) {
+        validateUserRole(userRole);
 
+        AirlineEntity airline = getAirlineById(airlineId);
+
+        airline.updateDeletionInfo(userId);
+    }
+
+    private AirlineEntity getAirlineById(UUID airlineId) {
         AirlineEntity airline = airlineRepository.findById(airlineId)
                 .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
+        return airline;
+    }
 
-//        airline.updateDeletionInfo();
+    private void getAirlineByCode(CreateAirlineCommand airlineCommand) {
+        if (airlineRepository.findByCode(airlineCommand.getCode()).isPresent()) {
+            throw new IllegalArgumentException("Airline code " + airlineCommand.getCode() + " already exists");
+        }
+    }
+
+    private void validateUserRole(String userRole) {
+        if(userRole.equals("CUSTOMER")){
+            throw new IllegalArgumentException("Access denied");
+        }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airport/AirportExternalService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airport/AirportExternalService.java
@@ -21,7 +21,9 @@ public class AirportExternalService {
     private final AirportRepository airportRepository;
 
     // 실시간 공항 정보 조회
-    public Location[] searchAirports(String keyword) throws Exception {
+    public Location[] searchAirports(String keyword, String userRole) throws Exception {
+        validateUserRole(userRole);
+
         return amadeus.referenceData.locations.get(
                 Params.with("subType", "AIRPORT")
                         .and("keyword", keyword)
@@ -30,7 +32,9 @@ public class AirportExternalService {
     }
 
     // 실시간 공항 정보 조회 및 DB 저장
-    public List<AirportResponse> searchAndSaveAirports(String keyword) throws Exception {
+    public List<AirportResponse> searchAndSaveAirports(String keyword, String userRole) throws Exception {
+        validateUserRole(userRole);
+
         Location[] locations = amadeus.referenceData.locations
                 .get(Params.with("keyword", keyword).and("subType", "AIRPORT"));
 
@@ -51,5 +55,11 @@ public class AirportExternalService {
                     return AirportResponse.from(airport);
                 })
                 .toList();
+    }
+
+    private void validateUserRole(String userRole) {
+        if(userRole.equals("CUSTOMER")) {
+            throw new IllegalArgumentException("Access denied");
+        }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airport/AirportService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airport/AirportService.java
@@ -1,11 +1,11 @@
 package com.oneul_tanda.flight_service.application.service.airport;
 
 import com.oneul_tanda.flight_service.application.dtos.airport.CreateAirportCommand;
-import com.oneul_tanda.flight_service.domain.entity.AirportEntity;
-import com.oneul_tanda.flight_service.presentation.dtos.airport.AirportResponse;
 import com.oneul_tanda.flight_service.application.dtos.airport.UpdateAirportCommand;
+import com.oneul_tanda.flight_service.domain.entity.AirportEntity;
 import com.oneul_tanda.flight_service.domain.repository.airport.AirportRepository;
 import com.oneul_tanda.flight_service.domain.repository.airport.AirportRepositoryCustom;
+import com.oneul_tanda.flight_service.presentation.dtos.airport.AirportResponse;
 import com.oneul_tanda.flight_service.util.PagingUtil;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,15 +25,17 @@ public class AirportService {
     private final AirportRepositoryCustom airportRepositoryCustom;
 
     @Cacheable(value = "airports", key = "#airportId")
-    public AirportResponse getAirport(UUID airportId) {
+    public AirportResponse getAirport(UUID airportId, String userRole) {
+        validateUserRole(userRole);
 
-        AirportEntity airport = airportRepository.findById(airportId)
-                .orElseThrow(() -> new IllegalArgumentException("Airport not found"));
+        AirportEntity airport = getAirportById(airportId);
 
         return AirportResponse.from(airport);
     }
 
-    public Page<AirportResponse> searchAirports(String keyword, Pageable pageable) {
+    public Page<AirportResponse> searchAirports(String keyword, Pageable pageable, String userRole) {
+        validateUserRole(userRole);
+
         Pageable adjusted = PagingUtil.adjustPageable(pageable);
         Page<AirportEntity> airports = airportRepositoryCustom.searchByKeyword(keyword, adjusted);
 
@@ -42,11 +44,10 @@ public class AirportService {
 
     @Transactional
     @CacheEvict(value = "airports", allEntries = true) // 캐시 무효화
-    public AirportResponse createAirport(CreateAirportCommand airportCommand) {
+    public AirportResponse createAirport(CreateAirportCommand airportCommand, UUID userId, String userRole) {
+        validateUserRole(userRole);
 
-        if (airportRepository.findByCode(airportCommand.getCode()).isPresent()) {
-            throw new IllegalArgumentException("Airport code " + airportCommand.getCode() + " already exists");
-        }
+        getAirportByCode(airportCommand);
 
         AirportEntity airport = AirportEntity.from(
                 airportCommand.getCode(),
@@ -56,16 +57,17 @@ public class AirportService {
         );
 
         airportRepository.save(airport);
+        airport.updateCreationInfo(userId);
 
         return AirportResponse.from(airport);
     }
 
     @Transactional
     @CacheEvict(value = "airports", allEntries = true) // 캐시 무효화
-    public AirportResponse updateAirport(UpdateAirportCommand airportCommand) {
+    public AirportResponse updateAirport(UpdateAirportCommand airportCommand, UUID userId, String userRole) {
+        validateUserRole(userRole);
 
-        AirportEntity airport = airportRepository.findById(airportCommand.getAirportId())
-                .orElseThrow(() -> new IllegalArgumentException("Airport not found"));
+        AirportEntity airport = getAirportById(airportCommand.getAirportId());
 
         airport.updateOf(
                 airportCommand.getCode(),
@@ -74,18 +76,35 @@ public class AirportService {
                 airportCommand.getCountry()
         );
 
-//        airport.updateModificationInfo();
+        airport.updateModificationInfo(userId);
 
         return AirportResponse.from(airport);
     }
 
     @Transactional
     @CacheEvict(value = "airports", allEntries = true) // 캐시 무효화
-    public void deleteAirport(UUID airportId) {
+    public void deleteAirport(UUID airportId, UUID userId, String userRole) {
+        validateUserRole(userRole);
 
-        AirportEntity airport = airportRepository.findById(airportId)
+        AirportEntity airport = getAirportById(airportId);
+
+        airport.updateDeletionInfo(userId);
+    }
+
+    private void getAirportByCode(CreateAirportCommand airportCommand) {
+        if (airportRepository.findByCode(airportCommand.getCode()).isPresent()) {
+            throw new IllegalArgumentException("Airport code " + airportCommand.getCode() + " already exists");
+        }
+    }
+
+    private AirportEntity getAirportById(UUID airportId) {
+        return airportRepository.findById(airportId)
                 .orElseThrow(() -> new IllegalArgumentException("Airport not found"));
+    }
 
-//        airport.updateDeletionInfo();
+    private void validateUserRole(String userRole) {
+        if (userRole.equals("CUSTOMER")) {
+            throw new IllegalArgumentException("Access denied");
+        }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightExternalService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightExternalService.java
@@ -35,36 +35,38 @@ public class FlightExternalService {
     private final AirportRepository airportRepository;
 
     // 실시간 항공편 정보 조회
-    @Cacheable(value = "flightOffers", key = "#departureAirportCode + '#' + #arrivalAirportCode + '#' + #departureDate.toLocalDate().toString() + '#' + #requiredSeats")
+    @Cacheable(value = "flightOffers",
+            key = "#departureAirportCode + '#' + #arrivalAirportCode + '#' + #departureDate.toLocalDate().toString() + '#' + #requiredSeats")
     public List<FlightResponse> searchFlights(String departureAirportCode, String arrivalAirportCode,
-                                              LocalDateTime departureDate, Integer requiredSeats) throws Exception {
+                                              LocalDateTime departureDate, Integer requiredSeats, String userRole) throws Exception {
+        validateUserRole(userRole);
+        // 과거 날짜 검증
+        checkDepartureDateInPast(departureDate);
+
         validateInputs(departureDate, requiredSeats);
+
         FlightOfferSearch[] offers = fetchFlightOffers(departureAirportCode, arrivalAirportCode,
                 departureDate.toLocalDate().toString(), requiredSeats);
         return extractFlightResponses(offers, false);
     }
 
-    @Cacheable(value = "flightOffers", key = "#departureAirportCode + '#' + #arrivalAirportCode + '#' + #departureDate.toLocalDate().toString() + '#' + #requiredSeats")
+    @Cacheable(value = "flightOffers",
+            key = "#departureAirportCode + '#' + #arrivalAirportCode + '#' + #departureDate.toLocalDate().toString() + '#' + #requiredSeats")
     public List<FlightResponse> searchAndSaveFlights(String departureAirportCode, String arrivalAirportCode,
-                                                     LocalDateTime departureDate, Integer requiredSeats)
-            throws Exception {
+                                                     LocalDateTime departureDate, Integer requiredSeats) throws Exception {
+        // 과거 날짜 검증
+        checkDepartureDateInPast(departureDate);
+
         validateInputs(departureDate, requiredSeats);
+
         FlightOfferSearch[] offers = fetchFlightOffers(departureAirportCode, arrivalAirportCode,
                 departureDate.toLocalDate().toString(), requiredSeats);
         return extractFlightResponses(offers, true);
     }
 
-    private void validateInputs(LocalDateTime departureDate, Integer requiredSeats) {
-        if (departureDate == null) {
-            throw new IllegalArgumentException("departureDate is required");
-        }
-        if (requiredSeats == null || requiredSeats <= 0) {
-            requiredSeats = 1;
-        }
-    }
-
     private FlightOfferSearch[] fetchFlightOffers(String departureAirportCode, String arrivalAirportCode,
                                                   String departureDate, Integer requiredSeats) throws Exception {
+
         return amadeus.shopping.flightOffersSearch.get(
                 Params.with("originLocationCode", departureAirportCode)
                         .and("destinationLocationCode", arrivalAirportCode)
@@ -74,7 +76,9 @@ public class FlightExternalService {
                         .and("max", 10));
     }
 
-    private List<FlightResponse> extractFlightResponses(FlightOfferSearch[] offers, boolean saveToDb) {
+    private List<FlightResponse> extractFlightResponses(
+            FlightOfferSearch[] offers, boolean saveToDb
+    ) {
         if (offers == null) {
             return new ArrayList<>();
         }
@@ -123,31 +127,75 @@ public class FlightExternalService {
         return flights;
     }
 
-    private FlightEntity saveOrUpdateFlight(String flightNum, String carrierCode, String departureAirportCode,
-                                            String arrivalAirportCode, LocalDateTime departureTime,
-                                            LocalDateTime arrivalTime, BigDecimal price, Integer remainingSeats) {
-        AirlineEntity airline = airlineRepository.findByCode(carrierCode)
-                .orElseGet(() -> airlineRepository.save(AirlineEntity.from(carrierCode, "Unknown Airline")));
+    private FlightEntity saveOrUpdateFlight(
+            String flightNum, String carrierCode, String departureAirportCode,
+            String arrivalAirportCode, LocalDateTime departureTime,
+            LocalDateTime arrivalTime, BigDecimal price, Integer remainingSeats
+    ) {
+        AirlineEntity airline = getAirlineByCode(carrierCode);
 
-        Optional<FlightEntity> existing = flightRepository.findByFlightNumAndDepartureDateAndArrivalDate(
-                flightNum, departureTime, arrivalTime);
+        Optional<FlightEntity> existingFlight = getExistingFlight(flightNum, departureTime, arrivalTime);
+
         FlightEntity flight;
-        if (existing.isEmpty()) {
-            AirportEntity departureAirport = airportRepository.findByCode(departureAirportCode)
-                    .orElseThrow(() -> new IllegalArgumentException(
-                            "Invalid departure airport code: " + departureAirportCode));
-            AirportEntity arrivalAirport = airportRepository.findByCode(arrivalAirportCode)
-                    .orElseThrow(
-                            () -> new IllegalArgumentException("Invalid arrival airport code: " + arrivalAirportCode));
+
+        if (existingFlight.isEmpty()) {
+            AirportEntity departureAirport = getDepartureAirport(departureAirportCode);
+            AirportEntity arrivalAirport = getArrivalAirport(arrivalAirportCode);
 
             flight = FlightEntity.from(
                     flightNum, airline, departureAirport, arrivalAirport,
                     departureTime, arrivalTime, Duration.between(departureTime, arrivalTime),
                     price, remainingSeats);
         } else {
-            flight = existing.get();
+            flight = existingFlight.get();
             flight.updateFromOffer(price, remainingSeats);
         }
         return flightRepository.save(flight);
+    }
+
+    private Optional<FlightEntity> getExistingFlight(String flightNum, LocalDateTime departureTime,
+                                                   LocalDateTime arrivalTime) {
+        return flightRepository.findByFlightNumAndDepartureDateAndArrivalDate(
+                flightNum, departureTime, arrivalTime);
+    }
+
+    private AirlineEntity getAirlineByCode(String carrierCode) {
+        return airlineRepository.findByCode(carrierCode)
+                .orElseGet(() -> airlineRepository.save(AirlineEntity.from(carrierCode, "Unknown Airline")));
+    }
+
+    private AirportEntity getArrivalAirport(String arrivalAirportCode) {
+        return airportRepository.findByCode(arrivalAirportCode)
+                .orElseThrow(
+                        () -> new IllegalArgumentException("Invalid arrival airport code: " + arrivalAirportCode));
+    }
+
+    private AirportEntity getDepartureAirport(String departureAirportCode) {
+        return airportRepository.findByCode(departureAirportCode)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Invalid departure airport code: " + departureAirportCode));
+    }
+
+    private void checkDepartureDateInPast(LocalDateTime departureDate) {
+        LocalDateTime now = LocalDateTime.now();
+        if (departureDate.toLocalDate().isBefore(now.toLocalDate())) {
+            log.warn("Requested departureDate {} is in the past", departureDate);
+            throw new IllegalArgumentException("departureDate cannot be in the past");
+        }
+    }
+
+    private void validateUserRole(String userRole) {
+        if(userRole.equals("CUSTOMER")) {
+            throw new IllegalArgumentException("Access denied");
+        }
+    }
+
+    private void validateInputs(LocalDateTime departureDate, Integer requiredSeats) {
+        if (departureDate == null) {
+            throw new IllegalArgumentException("departureDate is required");
+        }
+        if (requiredSeats == null || requiredSeats <= 0) {
+            requiredSeats = 1;
+        }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightService.java
@@ -36,16 +36,17 @@ public class FlightService {
     @Cacheable(value = "flights", key = "#flightId")
     public FlightDetailResponse getFlight(UUID flightId) {
 
-        FlightEntity flight = flightRepository.findById(flightId)
-                .orElseThrow(() -> new IllegalArgumentException("Flight not found"));
+        FlightEntity flight = getFlightById(flightId);
 
         return FlightDetailResponse.from(flight);
     }
 
     public Page<FlightResponse> searchFlights(String departureAirport, String arrivalAirport,
                                               LocalDateTime departureDate, Integer requiredSeats,
-                                              Pageable pageable
+                                              Pageable pageable, String userRole
     ) {
+        validateUserRole(userRole);
+
         Pageable adjusted = PagingUtil.adjustPageable(pageable);
         Page<FlightEntity> flights = flightRepositoryCustom.searchFlights(
                 departureAirport, arrivalAirport,
@@ -57,7 +58,8 @@ public class FlightService {
 
     @Transactional
     @CacheEvict(value = "flights", allEntries = true) // 캐시 무효화
-    public FlightResponse createFlight(CreateFlightCommand flightCommand) {
+    public FlightResponse createFlight(CreateFlightCommand flightCommand, UUID userId, String userRole) {
+        validateUserRole(userRole);
 
         if (flightRepository.findByFlightNumAndDepartureDate(flightCommand.getFlightNum(),
                         flightCommand.getDepartureDate())
@@ -66,12 +68,9 @@ public class FlightService {
         }
 
         // AirlineEntity와 Airport 엔티티 조회
-        AirlineEntity airline = airlineRepository.findByCode(flightCommand.getAirlineCode())
-                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
-        AirportEntity departureAirport = airportRepository.findByCode(flightCommand.getDepartureAirportCode())
-                .orElseThrow(() -> new IllegalArgumentException("Departure Airport not found"));
-        AirportEntity arrivalAirport = airportRepository.findByCode(flightCommand.getArrivalAirportCode())
-                .orElseThrow(() -> new IllegalArgumentException("Arrival Airport not found"));
+        AirlineEntity airline = getAirlineForCreateFlight(flightCommand);
+        AirportEntity departureAirport = getDepartureAirportForCreateFlight(flightCommand);
+        AirportEntity arrivalAirport = getArrivalAirportForCreateFlight(flightCommand);
 
         Duration duration = Duration.between(flightCommand.getDepartureDate(), flightCommand.getArrivalDate());
 
@@ -88,24 +87,20 @@ public class FlightService {
         );
 
         flightRepository.save(flight);
+        airline.updateCreationInfo(userId);
 
         return FlightResponse.from(flight);
     }
 
     @Transactional
     @CacheEvict(value = "flights", key = "#flightCommand.flightId") // 캐시 무효화
-    public FlightResponse updateFlight(UpdateFlightCommand flightCommand) {
+    public FlightResponse updateFlight(UpdateFlightCommand flightCommand, UUID userId, String userRole) {
+        validateUserRole(userRole);
+        FlightEntity flight = getFlightById(flightCommand.getFlightId());
 
-        FlightEntity flight = flightRepository.findById(flightCommand.getFlightId())
-                .orElseThrow(() -> new IllegalArgumentException("Flight not found"));
-
-        // AirlineEntity와 Airport 엔티티 조회
-        AirlineEntity airline = airlineRepository.findByCode(flightCommand.getAirlineCode())
-                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
-        AirportEntity departureAirport = airportRepository.findByCode(flightCommand.getDepartureAirportCode())
-                .orElseThrow(() -> new IllegalArgumentException("Departure Airport not found"));
-        AirportEntity arrivalAirport = airportRepository.findByCode(flightCommand.getArrivalAirportCode())
-                .orElseThrow(() -> new IllegalArgumentException("Arrival Airport not found"));
+        AirlineEntity airline = getAirlineForUpdateFlight(flightCommand);
+        AirportEntity departureAirport = getDepartureAirportForUpdateFlight(flightCommand);
+        AirportEntity arrivalAirport = getArrivalAirportForUpdateFlight(flightCommand);
 
         Duration duration = Duration.between(flightCommand.getDepartureDate(), flightCommand.getArrivalDate());
 
@@ -121,26 +116,25 @@ public class FlightService {
                 flightCommand.getRemainingSeats()
         );
 
-//        flight.updateModificationInfo();
+        flight.updateModificationInfo(userId);
 
         return FlightResponse.from(flight);
     }
 
     @Transactional
     @CacheEvict(value = "flights", key = "#flightId") // 캐시 무효화
-    public void deleteFlight(UUID flightId) {
+    public void deleteFlight(UUID flightId, UUID userId, String userRole) {
+        validateUserRole(userRole);
 
-        FlightEntity flight = flightRepository.findById(flightId)
-                .orElseThrow(() -> new IllegalArgumentException("Flight not found"));
+        FlightEntity flight = getFlightById(flightId);
 
-//        flight.updateDeletionInfo();
+        flight.updateDeletionInfo(userId);
     }
 
     @Transactional
     @CacheEvict(value = "flights", key = "#flightId") // 캐시 무효화
     public void decreaseSeats(UUID flightId, Integer requiredSeats) {
-        FlightEntity flight = flightRepository.findById(flightId)
-                .orElseThrow(() -> new IllegalArgumentException("Flight not found"));
+        FlightEntity flight = getFlightById(flightId);
 
         flight.decreaseSeatCount(requiredSeats);
     }
@@ -148,9 +142,49 @@ public class FlightService {
     @Transactional
     @CacheEvict(value = "flights", key = "#flightId") // 캐시 무효화
     public void increaseSeats(UUID flightId, Integer requiredSeats) {
-        FlightEntity flight = flightRepository.findById(flightId)
-                .orElseThrow(() -> new IllegalArgumentException("Flight not found"));
+        FlightEntity flight = getFlightById(flightId);
 
         flight.increaseSeatCount(requiredSeats);
+    }
+
+    private AirportEntity getArrivalAirportForUpdateFlight(UpdateFlightCommand flightCommand) {
+        return airportRepository.findByCode(flightCommand.getArrivalAirportCode())
+                .orElseThrow(() -> new IllegalArgumentException("Arrival Airport not found"));
+    }
+
+    private AirportEntity getDepartureAirportForUpdateFlight(UpdateFlightCommand flightCommand) {
+        return airportRepository.findByCode(flightCommand.getDepartureAirportCode())
+                .orElseThrow(() -> new IllegalArgumentException("Departure Airport not found"));
+    }
+
+    private AirlineEntity getAirlineForUpdateFlight(UpdateFlightCommand flightCommand) {
+        return airlineRepository.findByCode(flightCommand.getAirlineCode())
+                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
+    }
+
+    private AirportEntity getArrivalAirportForCreateFlight(CreateFlightCommand flightCommand) {
+        return airportRepository.findByCode(flightCommand.getArrivalAirportCode())
+                .orElseThrow(() -> new IllegalArgumentException("Arrival Airport not found"));
+    }
+
+    private AirportEntity getDepartureAirportForCreateFlight(CreateFlightCommand flightCommand) {
+        return airportRepository.findByCode(flightCommand.getDepartureAirportCode())
+                .orElseThrow(() -> new IllegalArgumentException("Departure Airport not found"));
+    }
+
+    private AirlineEntity getAirlineForCreateFlight(CreateFlightCommand flightCommand) {
+        return airlineRepository.findByCode(flightCommand.getAirlineCode())
+                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
+    }
+
+    private FlightEntity getFlightById(UUID flightId) {
+        return flightRepository.findById(flightId)
+                .orElseThrow(() -> new IllegalArgumentException("Flight not found"));
+    }
+
+    private void validateUserRole(String userRole) {
+        if(userRole.equals("CUSTOMER")) {
+            throw new IllegalArgumentException("Access denied");
+        }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/common/BaseTimeEntity.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/common/BaseTimeEntity.java
@@ -39,7 +39,7 @@ public class BaseTimeEntity {
     @Column(name = "deleted_by")
     private UUID deletedBy;
 
-    public void updateCreatedBy(UUID userId) {
+    public void updateCreationInfo(UUID userId) {
         this.createdBy = userId;
     }
 

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/JpaAuditorAware.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/JpaAuditorAware.java
@@ -18,7 +18,7 @@ public class JpaAuditorAware implements AuditorAware<String> {
         RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
         if (requestAttributes instanceof ServletRequestAttributes servletRequestAttributes) {
             HttpServletRequest request = servletRequestAttributes.getRequest();
-            String userId = request.getHeader("X-UserId");
+            String userId = request.getHeader("X-User-Id");
 
             return Optional.ofNullable(userId);
         } else {

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/AirlineController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/AirlineController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,9 +33,10 @@ public class AirlineController {
 
     @GetMapping("/{airlineId}")
     public ResponseEntity<AirlineResponse> getAirline(
-            @PathVariable UUID airlineId
+            @PathVariable UUID airlineId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        AirlineResponse response = airlineService.getAirline(airlineId);
+        AirlineResponse response = airlineService.getAirline(airlineId, userRole);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
@@ -42,32 +44,41 @@ public class AirlineController {
     public ResponseEntity<Page<AirlineResponse>> searchAirlines(
             @RequestParam(required = false) String code,
             @RequestParam(required = false) String name,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable
+            @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        Page<AirlineResponse> result = airlineService.searchAirlines(code, name, pageable);
+        Page<AirlineResponse> result = airlineService.searchAirlines(code, name, pageable, userRole);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
     @PostMapping
-    public ResponseEntity<AirlineResponse> createAirline(@RequestBody @Valid CreateAirlineRequest request) {
-        AirlineResponse response = airlineService.createAirline(request.toCommand());
+    public ResponseEntity<AirlineResponse> createAirline(
+            @RequestBody @Valid CreateAirlineRequest request,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
+    ) {
+        AirlineResponse response = airlineService.createAirline(request.toCommand(), userId, userRole);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{airlineId}")
     public ResponseEntity<AirlineResponse> updateAirline(
             @PathVariable UUID airlineId,
-            @RequestBody @Valid UpdateAirlineRequest request
+            @RequestBody @Valid UpdateAirlineRequest request,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        AirlineResponse response = airlineService.updateAirline(request.toCommand(airlineId));
+        AirlineResponse response = airlineService.updateAirline(request.toCommand(airlineId), userId, userRole);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @DeleteMapping("/{airlineId}")
     public ResponseEntity<Void> deleteAirline(
-            @PathVariable UUID airlineId
+            @PathVariable UUID airlineId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        airlineService.deleteAirline(airlineId);
+        airlineService.deleteAirline(airlineId, userId, userRole);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/AirportController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/AirportController.java
@@ -1,9 +1,9 @@
 package com.oneul_tanda.flight_service.presentation.controller;
 
-import com.oneul_tanda.flight_service.presentation.dtos.airport.UpdateAirportRequest;
 import com.oneul_tanda.flight_service.application.service.airport.AirportService;
-import com.oneul_tanda.flight_service.presentation.dtos.airport.CreateAirportRequest;
 import com.oneul_tanda.flight_service.presentation.dtos.airport.AirportResponse;
+import com.oneul_tanda.flight_service.presentation.dtos.airport.CreateAirportRequest;
+import com.oneul_tanda.flight_service.presentation.dtos.airport.UpdateAirportRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,43 +32,51 @@ public class AirportController {
 
     @GetMapping("/{airportId}")
     public ResponseEntity<AirportResponse> getAirport(
-            @PathVariable UUID airportId
+            @PathVariable UUID airportId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        AirportResponse response = airportService.getAirport(airportId);
+        AirportResponse response = airportService.getAirport(airportId, userRole);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @GetMapping("/search")
     public ResponseEntity<Page<AirportResponse>> searchAirports(
             @RequestParam(required = false, defaultValue = "") String keyword,
-            @PageableDefault Pageable pageable
+            @PageableDefault Pageable pageable,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        Page<AirportResponse> result = airportService.searchAirports(keyword, pageable);
+        Page<AirportResponse> result = airportService.searchAirports(keyword, pageable, userRole);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
     @PostMapping
     public ResponseEntity<AirportResponse> createAirport(
-            @RequestBody @Valid CreateAirportRequest request
+            @RequestBody @Valid CreateAirportRequest request,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        AirportResponse response = airportService.createAirport(request.toCommand());
+        AirportResponse response = airportService.createAirport(request.toCommand(), userId, userRole);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{airportId}")
     public ResponseEntity<AirportResponse> updateAirport(
             @PathVariable UUID airportId,
-            @RequestBody @Valid UpdateAirportRequest request
+            @RequestBody @Valid UpdateAirportRequest request,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        AirportResponse response = airportService.updateAirport(request.toCommand(airportId));
+        AirportResponse response = airportService.updateAirport(request.toCommand(airportId), userId, userRole);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @DeleteMapping("/{airportId}")
     public ResponseEntity<Void> deleteAirport(
-            @PathVariable UUID airportId
+            @PathVariable UUID airportId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        airportService.deleteAirport(airportId);
+        airportService.deleteAirport(airportId, userId, userRole);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/AmadeusController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/AmadeusController.java
@@ -19,6 +19,7 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,9 +36,12 @@ public class AmadeusController {
 
     // 실시간 공항 정보 조회용
     @GetMapping("/airports/live-search")
-    public ResponseEntity<List<AirportSearchResponse>> searchAirports(@RequestParam String keyword) {
+    public ResponseEntity<List<AirportSearchResponse>> searchAirports(
+            @RequestParam String keyword,
+            @RequestHeader ("X-User-Role") String userRole
+    ) {
         try {
-            Location[] locations = airportExternalService.searchAirports(keyword);
+            Location[] locations = airportExternalService.searchAirports(keyword, userRole);
             List<AirportSearchResponse> response = Arrays.stream(locations)
                     .map(AirportSearchResponse::from)
                     .toList();
@@ -50,9 +54,12 @@ public class AmadeusController {
 
     // 실시간 공항 정보 조회 및 DB 저장용
     @PostMapping("/airports/fetch-and-save")
-    public ResponseEntity<List<AirportResponse>> searchAndSaveAirports(@RequestParam String keyword) {
+    public ResponseEntity<List<AirportResponse>> searchAndSaveAirports(
+            @RequestParam String keyword,
+            @RequestHeader ("X-User-Role") String userRole
+    ) {
         try {
-            return ResponseEntity.ok(airportExternalService.searchAndSaveAirports(keyword));
+            return ResponseEntity.ok(airportExternalService.searchAndSaveAirports(keyword, userRole));
         } catch (Exception e) {
             log.error("Error fetching and saving airports: {}", e.getMessage());
             return ResponseEntity.internalServerError().build();
@@ -61,9 +68,12 @@ public class AmadeusController {
 
     // 실시간 항공사 정보 조회용
     @GetMapping("/airlines/live-search")
-    public ResponseEntity<List<AirlineSearchResponse>> searchAirlines(@RequestParam String keyword) {
+    public ResponseEntity<List<AirlineSearchResponse>> searchAirlines(
+            @RequestParam String keyword,
+            @RequestHeader ("X-User-Role") String userRole
+    ) {
         try {
-            List<AirlineSearchResponse> airlineResponses = airlineExternalService.searchAirlines(keyword);
+            List<AirlineSearchResponse> airlineResponses = airlineExternalService.searchAirlines(keyword, userRole);
             return ResponseEntity.ok(airlineResponses);
         } catch (Exception e) {
             log.error("Error while fetching airlines", e);
@@ -73,9 +83,12 @@ public class AmadeusController {
 
     // 실시간 항공사 정보 조회 및 DB 저장용
     @PostMapping("/airlines/fetch-and-save")
-    public ResponseEntity<List<AirlineResponse>> searchAndSaveAirlines(@RequestParam String keyword) {
+    public ResponseEntity<List<AirlineResponse>> searchAndSaveAirlines(
+            @RequestParam String keyword,
+            @RequestHeader ("X-User-Role") String userRole
+    ) {
         try {
-            return ResponseEntity.ok(airlineExternalService.searchAndSaveAirlines(keyword));
+            return ResponseEntity.ok(airlineExternalService.searchAndSaveAirlines(keyword, userRole));
         } catch (Exception e) {
             log.error("Error fetching and saving airlines: {}", e.getMessage());
             return ResponseEntity.internalServerError().build();
@@ -88,11 +101,12 @@ public class AmadeusController {
             @RequestParam String departureAirportCode,
             @RequestParam String arrivalAirportCode,
             @RequestParam @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime departureDate,
-            @RequestParam Integer requiredSeats
+            @RequestParam Integer requiredSeats,
+            @RequestHeader ("X-User-Role") String userRole
     ) {
         try {
             List<FlightResponse> flightResponses = flightExternalService.searchFlights(
-                    departureAirportCode, arrivalAirportCode, departureDate, requiredSeats);
+                    departureAirportCode, arrivalAirportCode, departureDate, requiredSeats, userRole);
             return ResponseEntity.ok(flightResponses);
         } catch (Exception e) {
             log.error("Error while searching flights", e);
@@ -109,12 +123,6 @@ public class AmadeusController {
             @RequestParam Integer requiredSeats
     ) {
         try {
-            // 과거 날짜 검증
-            LocalDateTime now = LocalDateTime.now();
-            if (departureDate.toLocalDate().isBefore(now.toLocalDate())) {
-                log.warn("Requested departureDate {} is in the past", departureDate);
-                return ResponseEntity.badRequest().body(List.of());
-            }
             List<FlightResponse> response = flightExternalService.searchAndSaveFlights(
                     departureAirportCode, arrivalAirportCode, departureDate, requiredSeats);
             return ResponseEntity.ok(response);

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/FlightController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/FlightController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,51 +48,44 @@ public class FlightController {
             @RequestParam(required = false) String arrivalAirport,
             @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime departureDate,
             @RequestParam(required = false) Integer requiredSeats,
-            @PageableDefault Pageable pageable
+            @PageableDefault Pageable pageable,
+            @RequestHeader("X-User-Role") String userRole
     ) {
         Page<FlightResponse> result = flightService.searchFlights(
                 departureAirport, arrivalAirport,
                 departureDate, requiredSeats,
-                pageable);
+                pageable, userRole);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
     @PostMapping
     public ResponseEntity<FlightResponse> createFlight(
-            @RequestBody @Valid CreateFlightRequest request
+            @RequestBody @Valid CreateFlightRequest request,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        FlightResponse response = flightService.createFlight(request.toCommand());
+        FlightResponse response = flightService.createFlight(request.toCommand(), userId, userRole);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{flightId}")
     public ResponseEntity<FlightResponse> updateFlight(
             @PathVariable UUID flightId,
-            @RequestBody @Valid UpdateFlightRequest request
+            @RequestBody @Valid UpdateFlightRequest request,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        FlightResponse response = flightService.updateFlight(request.toCommand(flightId));
+        FlightResponse response = flightService.updateFlight(request.toCommand(flightId), userId, userRole);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @DeleteMapping("/{flightId}")
     public ResponseEntity<Void> deleteFlight(
-            @PathVariable UUID flightId
+            @PathVariable UUID flightId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        flightService.deleteFlight(flightId);
+        flightService.deleteFlight(flightId, userId, userRole);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
-    // 좌석 차감
-    @PutMapping("/{flightId}/seats/decrease")
-    public ResponseEntity<Void> decreaseSeats(@PathVariable UUID flightId, @RequestParam Integer requiredSeats) {
-        flightService.decreaseSeats(flightId, requiredSeats);
-        return ResponseEntity.status(HttpStatus.OK).build();
-    }
-
-    // 좌석 복구
-    @PutMapping("/{flightId}/seats/increase")
-    public ResponseEntity<Void> increaseSeats(@PathVariable UUID flightId, @RequestParam Integer requiredSeats) {
-        flightService.increaseSeats(flightId, requiredSeats);
-        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/InternalController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/InternalController.java
@@ -1,0 +1,40 @@
+package com.oneul_tanda.flight_service.presentation.controller;
+
+import com.oneul_tanda.flight_service.application.service.flight.FlightService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/flights/{flightId}/seats")
+public class InternalController {
+
+    private final FlightService flightService;
+
+    // 좌석 차감
+    @PutMapping("/decrease")
+    public ResponseEntity<Void> decreaseSeats(
+            @PathVariable UUID flightId,
+            @RequestParam Integer requiredSeats
+    ) {
+        flightService.decreaseSeats(flightId, requiredSeats);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    // 좌석 복구
+    @PutMapping("/increase")
+    public ResponseEntity<Void> increaseSeats(
+            @PathVariable UUID flightId,
+            @RequestParam Integer requiredSeats
+    ) {
+        flightService.increaseSeats(flightId, requiredSeats);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/init-scripts/01-init-flight-db.sql
+++ b/init-scripts/01-init-flight-db.sql
@@ -23,20 +23,11 @@ CREATE TABLE IF NOT EXISTS p_airlines
     100
 ) NOT NULL,
     created_at TIMESTAMP,
-    created_by VARCHAR
-(
-    100
-),
+    created_by UUID,
     updated_at TIMESTAMP,
-    updated_by VARCHAR
-(
-    100
-),
+    updated_by UUID,
     deleted_at TIMESTAMP,
-    deleted_by VARCHAR
-(
-    100
-)
+    deleted_by UUID
     );
 
 -- 공항 테이블
@@ -65,20 +56,11 @@ CREATE TABLE IF NOT EXISTS p_airports
 ) NOT NULL,
 
     created_at TIMESTAMP,
-    created_by VARCHAR
-(
-    100
-),
+    created_by UUID,
     updated_at TIMESTAMP,
-    updated_by VARCHAR
-(
-    100
-),
+    updated_by UUID,
     deleted_at TIMESTAMP,
-    deleted_by VARCHAR
-(
-    100
-)
+    deleted_by UUID
     );
 
 -- 항공편 테이블
@@ -107,20 +89,11 @@ CREATE TABLE IF NOT EXISTS p_flights
     remaining_seats INTEGER NOT NULL,
 
     created_at TIMESTAMP,
-    created_by VARCHAR
-(
-    100
-),
+    created_by UUID,
     updated_at TIMESTAMP,
-    updated_by VARCHAR
-(
-    100
-),
+    updated_by UUID,
     deleted_at TIMESTAMP,
-    deleted_by VARCHAR
-(
-    100
-),
+    deleted_by UUID,
     CONSTRAINT fk_flight_airline FOREIGN KEY
 (
     airline_id

--- a/queue-service/src/main/java/com/sparta/queueservice/infrastructure/client/FlightClient.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/infrastructure/client/FlightClient.java
@@ -15,6 +15,6 @@ public interface FlightClient {
     FlightResponse getFlight(@PathVariable UUID flightId);
 
     // 대기열 선점 성공시 좌석 수 차감 로직 api
-    @PutMapping("/api/v1/flights/{flightId}/seats/decrease")
+    @PutMapping("/internal/v1/flights/{flightId}/seats/decrease")
     void decreaseSeats(@PathVariable UUID flightId, @RequestParam Integer requiredSeats);
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/client/FlightFeignClient.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/client/FlightFeignClient.java
@@ -23,13 +23,13 @@ public interface FlightFeignClient {
     /**
      * 좌석 차감
      */
-    @PutMapping("/api/v1/flights/{flightId}/seats/decrease")
+    @PutMapping("/internal/v1/flights/{flightId}/seats/decrease")
     ResponseEntity<Void> decreaseSeats(@PathVariable UUID flightId, @RequestParam Integer requiredSeats);
 
 
     /**
      * 좌석 복구
      */
-    @PutMapping("/api/v1/flights/{flightId}/seats/increase")
+    @PutMapping("/internal/v1/flights/{flightId}/seats/increase")
     ResponseEntity<Void> increaseSeats(@PathVariable UUID flightId, @RequestParam Integer requiredSeats);
 }


### PR DESCRIPTION
## 💡 이슈
resolve #79 

## 🤩 개요
flight-service user validate 로직 추가

## 🧑‍💻 작업 사항
- RequestHeader 추가하여 사용자 정보 받아오고, 검증 로직 추가(테스트 완료)
- 좌석 수 변경 기능은 내부에서만 사용하기 때문에 컨트롤러 분리 및 주소 변경
  해당 api 사용하는 queue-service와 reservation-service의 FlightClient 주소도 함께 변경
- init script 테이블 생성시 생성자, 수정자, 삭제자 컬럼 varchar(100) -> UUID 로 변경 

## 📖 참고 사항
