### PR TITLE
Feat/#84 feat user dto validation

### DIFF
--- a/api-http-test/integration.http
+++ b/api-http-test/integration.http
@@ -27,16 +27,20 @@ Content-Type: application/json
   "password": "12345678a*"
 }
 
+> {%
+    // 로그인 응답에서 access_token 값을 추출해서 `access_token` 변수에 저장
+    client.global.set("access_token", response.headers.valueOf("Authorization"));
+%}
 
 ### 항공편 조회 및 저장
 POST http://localhost:19091/api/v1/amadeus/flights/fetch-and-save?departureAirportCode=LGW&arrivalAirportCode=KWE&departureDate=2025-04-25T19:45:25&requiredSeats=2
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpZCI6ImQ3NzE0MDg4LTE4OTEtNDBmOS1iNDNlLTJlOTgwM2U2MzE0ZiIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDUzMDEwMTUsImV4cCI6MTc0NTMwMjgxNX0.mjvlh3wV97thpEEiXPjfIkRIPrLVcDs3H4ilRNn4Xwg
+Authorization: Bearer {{access_token}}
 
 
 ### 특가 항공권 예매 요청
 POST http://localhost:19091/api/v1/queue
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpZCI6ImQ3NzE0MDg4LTE4OTEtNDBmOS1iNDNlLTJlOTgwM2U2MzE0ZiIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDUzMDEwMTUsImV4cCI6MTc0NTMwMjgxNX0.mjvlh3wV97thpEEiXPjfIkRIPrLVcDs3H4ilRNn4Xwg\
+Authorization: Bearer {{access_token}}
 
 {
   "flightId" : "66b08c46-8393-480a-a8bc-3d72dcda80dd",
@@ -47,14 +51,15 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTV
 ### 예약 단일 조회
 GET http://localhost:19091/api/v1/reservations/9b7f421f-47b0-47f5-aa5c-8f489697a57d
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpZCI6ImQ3NzE0MDg4LTE4OTEtNDBmOS1iNDNlLTJlOTgwM2U2MzE0ZiIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDUzMDEwMTUsImV4cCI6MTc0NTMwMjgxNX0.mjvlh3wV97thpEEiXPjfIkRIPrLVcDs3H4ilRNn4Xwg\
+Authorization: Bearer {{access_token}}
 
 
 ## 예약 목록 조회
 ### 예약 목록 조회 - Default
 GET http://localhost:19091/api/v1/reservations
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpZCI6ImQ3NzE0MDg4LTE4OTEtNDBmOS1iNDNlLTJlOTgwM2U2MzE0ZiIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDUzMDEwMTUsImV4cCI6MTc0NTMwMjgxNX0.mjvlh3wV97thpEEiXPjfIkRIPrLVcDs3H4ilRNn4Xwg\
+Authorization: Bearer {{access_token}}
+
 
 ### 예약 대기열 서비스 Kafka prodcuer: 예약 선점 성공 이벤트 발행
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,6 @@ services:
       MYSQL_PASSWORD: 1234
     ports:
       - "3309:3306"
-    #todo: 추후에 port 확인, 변경 필요
     volumes:
       - user-mysql-data:/var/lib/mysql
 
@@ -163,6 +162,8 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - zookeeper
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
@@ -174,6 +175,9 @@ services:
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
       KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
       KAFKA_CLUSTERS_0_READONLY: "false"
+    depends_on:
+      - zookeeper
+
 
   grafana:
     image: grafana/grafana:latest
@@ -186,6 +190,8 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
 
   prometheus:
     image: prom/prometheus:latest

--- a/gateway-service/src/main/java/com/oneultanda/gatewayservice/infrastructure/filter/JwtAuthorizationFilter.java
+++ b/gateway-service/src/main/java/com/oneultanda/gatewayservice/infrastructure/filter/JwtAuthorizationFilter.java
@@ -7,14 +7,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
-
-import java.util.UUID;
 
 @Slf4j
 @Component
@@ -31,9 +30,14 @@ public class JwtAuthorizationFilter implements GlobalFilter, Ordered {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         String path = exchange.getRequest().getPath().toString();
+        HttpMethod method = exchange.getRequest().getMethod();
 
         //토큰 없이 통과
-        if (path.startsWith("/api/v1/users/signup") || path.startsWith("/api/v1/users/login")) {
+        if (path.startsWith("/api/v1/users/signup") && method.equals(HttpMethod.POST)
+                || path.startsWith("/api/v1/users/login") && method.equals(HttpMethod.POST)
+                || path.startsWith("/api/v1/flights") && method.equals(HttpMethod.GET)
+                || path.startsWith("/api/v1/amadeus/flights/fetch-and-save") && method.equals(HttpMethod.POST)
+        ) {
             log.info("토큰없이 통과");
             return chain.filter(exchange);
         }
@@ -63,7 +67,6 @@ public class JwtAuthorizationFilter implements GlobalFilter, Ordered {
                 .build();
 
         log.info("토큰 검즘확인: " + username);
-        log.info(userId.toString());
 
         return chain.filter(mutatedExchange);
     }

--- a/gateway-service/src/main/java/com/oneultanda/gatewayservice/infrastructure/kafka/KafkaConsumerService.java
+++ b/gateway-service/src/main/java/com/oneultanda/gatewayservice/infrastructure/kafka/KafkaConsumerService.java
@@ -30,7 +30,7 @@ public class KafkaConsumerService {
             redisTemplate.opsForValue().set(key, String.valueOf(event.tokenVersion()), Duration.ofMinutes(toKenVersionExpiration));
 
         } catch(Exception e) {
-            // todo: 실패에 대한 보상처리 과정
+            // todo: 실패에 대한 보상처리 과정(redis 이상인 경우)
             log.error("토큰 만료 처리 실패", e.getMessage(), e);
         }
     }

--- a/gateway-service/src/test/http/gateway.http
+++ b/gateway-service/src/test/http/gateway.http
@@ -74,7 +74,7 @@ Authorization: Bearer {{access_token}}
 }
 
 ### 유저 조회 userId기반
-GET http://localhost:19091/api/v1/users/43392dc4-3848-426d-bdfa-99946b3bedbb
+GET http://localhost:19091/internal/v1/users/09a6b989-86e0-4244-a120-683aef98a599
 Content-Type: application/json
 
 

--- a/gateway-service/src/test/http/gateway.http
+++ b/gateway-service/src/test/http/gateway.http
@@ -19,15 +19,20 @@ Content-Type: application/json
   "password": "12345678a*"
 }
 
+> {%
+    // 로그인 응답에서 access_token 값을 추출해서 `access_token` 변수에 저장
+    client.global.set("access_token", response.headers.valueOf("Authorization"));
+%}
+
 ### 유저 조회(개인)
 GET http://localhost:19091/api/v1/users/me
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJ0b2tlblZlcnNpb24iOjEsImlkIjoiYjNlNDg0OWYtNjllOC00MzU0LWIxNjYtNTUyZTA1ZWM4MWEzIiwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDUyMDQxMDcsImV4cCI6MTc0NTIwNTkwN30.9fZp38aeYgZcXvW8BqKA30Nx40Al__M6jw6gsg3Ermo
+Authorization: Bearer {{access_token}}
 
 ### 유저 정보 수정
 PUT http://localhost:19091/api/v1/users/me
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJ0b2tlblZlcnNpb24iOjEsImlkIjoiYjNlNDg0OWYtNjllOC00MzU0LWIxNjYtNTUyZTA1ZWM4MWEzIiwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDUyMDQxMDcsImV4cCI6MTc0NTIwNTkwN30.9fZp38aeYgZcXvW8BqKA30Nx40Al__M6jw6gsg3Ermo
+Authorization: Bearer {{access_token}}
 
 {
   "nickname": "테스터",
@@ -38,7 +43,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTV
 ### 유저 암호 수정
 PUT http://localhost:19091/api/v1/users/password
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJ0b2tlblZlcnNpb24iOjEsImlkIjoiYjNlNDg0OWYtNjllOC00MzU0LWIxNjYtNTUyZTA1ZWM4MWEzIiwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDUyMDQxMDcsImV4cCI6MTc0NTIwNTkwN30.9fZp38aeYgZcXvW8BqKA30Nx40Al__M6jw6gsg3Ermo
+Authorization: BBearer {{access_token}}
 
 {
   "currentPassword": "12345678a*",
@@ -48,7 +53,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTV
 ### 유저 탈퇴 todo: 추후 feignclient grpc를 통해 수정 작업 진행
 DELETE http://localhost:19091/api/v1/users/me
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpZCI6ImFhZGFlYjFlLTdhNmUtNDVjZC1hZTgzLWU1YjY2NTBjZWYyNCIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDQ5NzA4MDQsImV4cCI6MTc0NDk3MjYwNH0.Ox4FPo5JST6nGttFVkklweWUE3NddZen6YHKAl_Z_Ao
+Authorization: Bearer {{access_token}}
 
 {
   "password": "12345678a"
@@ -57,12 +62,12 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTV
 ### 유저 조회 username기반
 GET http://localhost:19091/api/v1/users/admin/tester
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpZCI6ImFhZGFlYjFlLTdhNmUtNDVjZC1hZTgzLWU1YjY2NTBjZWYyNCIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDQ5NzA4MDQsImV4cCI6MTc0NDk3MjYwNH0.Ox4FPo5JST6nGttFVkklweWUE3NddZen6YHKAl_Z_Ao
+Authorization: Bearer {{access_token}}
 
 ### 유저 권한 상승 username기반
 PUT http://localhost:19091/api/v1/users/admin/tester
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpZCI6ImFhZGFlYjFlLTdhNmUtNDVjZC1hZTgzLWU1YjY2NTBjZWYyNCIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDQ5NzA4MDQsImV4cCI6MTc0NDk3MjYwNH0.Ox4FPo5JST6nGttFVkklweWUE3NddZen6YHKAl_Z_Ao
+Authorization: Bearer {{access_token}}
 
 {
   "role": "MANAGER"

--- a/user-service/src/main/java/com/oneultanda/userservice/application/exception/ApplicationErrorCode.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/application/exception/ApplicationErrorCode.java
@@ -6,10 +6,13 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum ApplicationErrorCode implements ErrorCode {
+
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다"),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    PASSWORD_MISMATCH(HttpStatus.NOT_FOUND, "비밀번호가 일치하지 않습니다."),
+    LOGIN_MISMATCH(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 일치하지 않습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다");
-    // todo: 추후 좀더 상세하게 error 처리 ex) 아이디 비밀번호 불일치
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/user-service/src/main/java/com/oneultanda/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/application/service/UserService.java
@@ -2,11 +2,11 @@ package com.oneultanda.userservice.application.service;
 
 import com.oneultanda.userservice.application.dto.comand.*;
 import com.oneultanda.userservice.application.exception.ApplicationErrorCode;
+import com.oneultanda.userservice.common.exception.CustomException;
 import com.oneultanda.userservice.domain.model.Role;
 import com.oneultanda.userservice.domain.model.User;
 import com.oneultanda.userservice.domain.repository.UserRepository;
 import com.oneultanda.userservice.infrastructure.jwt.JwtUtil;
-import com.oneultanda.userservice.common.exception.CustomException;
 import com.oneultanda.userservice.infrastructure.kafka.KafkaProducerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,11 +42,30 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
+    public Boolean checkUsername(final String username) {
+        try {
+            User user = checkUserFromUsername(username);
+            return true;
+        } catch (CustomException e) {
+            return false;
+        }
+    }
+
+    @Transactional(readOnly = true)
     public String loginUser(LoginUserCommand command) {
-        User user = checkUserFromUsername(command.username());
-        checkPassword(user, command.password());
-        String accessToken = jwtUtil.createAccessToken(user.getUsername(), user.getRole(), user.getId(), user.getTokenVersion());
-        return accessToken;
+        try {
+            User user = checkUserFromUsername(command.username());
+            checkPassword(user, command.password());
+            String accessToken = jwtUtil.createAccessToken(
+                    user.getUsername(),
+                    user.getRole(),
+                    user.getId(),
+                    user.getTokenVersion()
+            );
+            return accessToken;
+        } catch (CustomException e) {
+            throw new CustomException(ApplicationErrorCode.LOGIN_MISMATCH);
+        }
     }
 
     /**
@@ -123,20 +142,20 @@ public class UserService {
     private User checkUser(final UUID userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() ->
-                new CustomException(ApplicationErrorCode.RESOURCE_NOT_FOUND));
+                new CustomException(ApplicationErrorCode.USER_NOT_FOUND));
     }
 
 
     private void checkPassword(final User user, final String rawPassword) {
         if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
-            throw new CustomException(ApplicationErrorCode.INVALID_REQUEST);
+            throw new CustomException(ApplicationErrorCode.PASSWORD_MISMATCH);
         }
     }
 
     private User checkUserFromUsername(final String username) {
         User user = userRepository.findByUsernameAndDeletedAtIsNull(username)
                 .orElseThrow(() ->
-                        new CustomException(ApplicationErrorCode.RESOURCE_NOT_FOUND));
+                        new CustomException(ApplicationErrorCode.USER_NOT_FOUND));
         return user;
     }
 

--- a/user-service/src/main/java/com/oneultanda/userservice/common/exception/RoleValidator.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/common/exception/RoleValidator.java
@@ -1,0 +1,24 @@
+package com.oneultanda.userservice.common.exception;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RoleValidator implements ConstraintValidator<ValidRole, String> {
+    private Set<String> acceptedValues;
+
+    @Override
+    public void initialize(ValidRole annotation) {
+        acceptedValues = Arrays.stream(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value != null && acceptedValues.contains(value);
+    }
+}

--- a/user-service/src/main/java/com/oneultanda/userservice/common/exception/ValidRole.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/common/exception/ValidRole.java
@@ -1,0 +1,20 @@
+package com.oneultanda.userservice.common.exception;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = RoleValidator.class)
+public @interface ValidRole {
+    String message() default "올바르지 않은 권한 값입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends Enum<?>> enumClass();
+}

--- a/user-service/src/main/java/com/oneultanda/userservice/common/validation/RoleValidator.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/common/validation/RoleValidator.java
@@ -1,4 +1,4 @@
-package com.oneultanda.userservice.common.exception;
+package com.oneultanda.userservice.common.validation;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/user-service/src/main/java/com/oneultanda/userservice/common/validation/ValidRole.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/common/validation/ValidRole.java
@@ -1,4 +1,4 @@
-package com.oneultanda.userservice.common.exception;
+package com.oneultanda.userservice.common.validation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;

--- a/user-service/src/main/java/com/oneultanda/userservice/domain/model/User.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/domain/model/User.java
@@ -1,6 +1,5 @@
 package com.oneultanda.userservice.domain.model;
 
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/user-service/src/main/java/com/oneultanda/userservice/infrastructure/jwt/JwtUtil.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/infrastructure/jwt/JwtUtil.java
@@ -4,7 +4,6 @@ import com.oneultanda.userservice.domain.model.Role;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecureDigestAlgorithm;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +15,6 @@ import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 
-@Slf4j
 @Component
 public class JwtUtil {
     private final SecretKey secretKey;
@@ -32,7 +30,6 @@ public class JwtUtil {
             @Value("${jwt.access-expiration}") Long accessExpiration,
             @Value("${jwt.refresh-expiration}") Long refreshExpiration
     ) {
-        log.info("-------------------------------------------" + secret);
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
         this.issuer = issuer;
         this.accessExpiration = accessExpiration;
@@ -60,7 +57,6 @@ public class JwtUtil {
     private String generateToken(Duration expiration, String username, Map<String, Object> claims) {
         // aws 의 리전이 어디에 생길지 모르니 타임 존을 명확하게 ...
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-        log.info(secretKey.toString());
         return Jwts.builder()
                 .subject(username)
                 .claims(claims)

--- a/user-service/src/main/java/com/oneultanda/userservice/infrastructure/kafka/KafkaProducerConfig.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/infrastructure/kafka/KafkaProducerConfig.java
@@ -8,9 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.support.converter.JsonMessageConverter;
-import org.springframework.kafka.support.converter.RecordMessageConverter;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;

--- a/user-service/src/main/java/com/oneultanda/userservice/infrastructure/repository/UserJpaRepository.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/infrastructure/repository/UserJpaRepository.java
@@ -1,6 +1,5 @@
 package com.oneultanda.userservice.infrastructure.repository;
 
-import com.oneultanda.userservice.domain.model.User;
 import com.oneultanda.userservice.infrastructure.entity.UserJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/controller/UserController.java
@@ -22,7 +22,7 @@ public class UserController {
     private final UserService userservice;
 
     /**
-     * todo: auth를 통해 암호화 등의 작업을 거친뒤 단순 저장 작업을 여기서 진행
+     * 회원가입
      */
     @PostMapping("/signup")
     public ResponseEntity<Void> registerUser(
@@ -30,6 +30,17 @@ public class UserController {
     ) {
         userservice.registerUser(request.toCommand());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
+     * 회원가입시 username 중복체크
+     */
+    @GetMapping("/exists")
+    public ResponseEntity<Boolean> checkUsername(
+            @RequestParam String username
+    ) {
+        boolean isUsername= userservice.checkUsername(username);
+        return ResponseEntity.ok(isUsername);
     }
 
     /**
@@ -67,9 +78,6 @@ public class UserController {
     }
 
     /**
-     * todo: 비밀번호 변경시 로그아웃 처리 필요(blacklist 등록) - auth에서 진행
-     * todo: auth에서 암호화까지 거친뒤 값을 받아옴
-     * todo: 추후 feignclient grpc를 통해 수정 작업 진행
      * todo: 시간 여유나면 email 인증 or email로 변경된 비밀번호 or 비빌번호 변경 링크 보내기 형식
      */
     @PutMapping("/password")
@@ -81,7 +89,7 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
     /**
-     * todo: 비밀번호 변경과 동일한 과정 필요
+     * 계정 삭제(소프트 딜리트0
      */
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteUser(
@@ -93,9 +101,7 @@ public class UserController {
     }
 
     /**
-     * todo: 관리자 대상 (get, seardh)(username 기반) gateway에서 토큰처리 함에 있어서도 필요함
-     * todo: gateway에서 권한 있는 사람만 사용가능하게 설정 + id값 필요시 feignclient 요청
-     * todo: gateway에서 권한 있는 사람만 사용가능하게 설정 + gateway에서 feignclient 요청시 header에 권한담아서 요청 + 내부에서 권한 검증 진행
+     * todo: 현재 내부에서 권한 확인하고 있지만 이걸 gateway에서 진행해줘야하는가?
      */
     @GetMapping("/admin/{username}")
     public ResponseEntity<UserResponse> getUserFromUsername(
@@ -107,6 +113,10 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+
+    /**
+     * username으로 관리자 권한 변경
+     */
     @PutMapping("/admin/{username}")
     public ResponseEntity<Void> updateRole(
             @RequestHeader("X-User-Role") final Role role,
@@ -117,6 +127,10 @@ public class UserController {
         return ResponseEntity.ok().location(location).build();
     }
 
+    /**
+     * 외부에서는 접근 불가능하도록 해야하는 feign client 전용
+     * todo: 1. 분리하기 2. gateway에서 이곳으로의 접근 차단or 없는 url인척하기
+     */
     @GetMapping("/{userId}")
     public ResponseEntity<UserResponse> getUserFromUserId(
             @PathVariable final UUID userId

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/controller/UserController.java
@@ -41,7 +41,7 @@ public class UserController {
     ) {
         String accessToken = userservice.loginUser(request.toCommand());
         return ResponseEntity.ok()
-                .header("Authorization", "Bearer " + accessToken)
+                .header("Authorization", accessToken)
                 .build();
     }
 

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/controller/UserController.java
@@ -101,7 +101,7 @@ public class UserController {
     }
 
     /**
-     * todo: 현재 내부에서 권한 확인하고 있지만 이걸 gateway에서 진행해줘야하는가?
+     * admin만 가능한 유저정보 조회
      */
     @GetMapping("/admin/{username}")
     public ResponseEntity<UserResponse> getUserFromUsername(
@@ -126,18 +126,4 @@ public class UserController {
         URI location = userservice.updateRole(role, username, request.toCommand());
         return ResponseEntity.ok().location(location).build();
     }
-
-    /**
-     * 외부에서는 접근 불가능하도록 해야하는 feign client 전용
-     * todo: 1. 분리하기 2. gateway에서 이곳으로의 접근 차단or 없는 url인척하기
-     */
-    @GetMapping("/{userId}")
-    public ResponseEntity<UserResponse> getUserFromUserId(
-            @PathVariable final UUID userId
-    ) {
-        User user = userservice.getUser(userId);
-        UserResponse response = UserResponse.fromUser(user);
-        return ResponseEntity.ok(response);
-    }
-
 }

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/controller/UserInternalController.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/controller/UserInternalController.java
@@ -1,0 +1,31 @@
+package com.oneultanda.userservice.presentation.controller;
+
+import com.oneultanda.userservice.application.service.UserService;
+import com.oneultanda.userservice.domain.model.User;
+import com.oneultanda.userservice.presentation.dto.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/internal/v1/users")
+@RequiredArgsConstructor
+public class UserInternalController {
+
+    private final UserService userservice;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserResponse> getUserFromUserId(
+            @PathVariable final UUID userId
+    ) {
+        User user = userservice.getUser(userId);
+        UserResponse response = UserResponse.fromUser(user);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/DeleteUserRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/DeleteUserRequest.java
@@ -1,8 +1,11 @@
 package com.oneultanda.userservice.presentation.dto.request;
 
 import com.oneultanda.userservice.application.dto.comand.DeleteUserCommand;
+import jakarta.validation.constraints.NotBlank;
 
 public record DeleteUserRequest(
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         String password
 ) {
     public DeleteUserCommand toCommand() {

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/LoginUserRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/LoginUserRequest.java
@@ -2,7 +2,6 @@ package com.oneultanda.userservice.presentation.dto.request;
 
 import com.oneultanda.userservice.application.dto.comand.LoginUserCommand;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record LoginUserRequest(
 

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/LoginUserRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/LoginUserRequest.java
@@ -1,13 +1,14 @@
 package com.oneultanda.userservice.presentation.dto.request;
 
 import com.oneultanda.userservice.application.dto.comand.LoginUserCommand;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record LoginUserRequest(
 
-        @NotNull(message = "계정명은 필수입니다.")
+        @NotBlank(message = "계정명은 필수 입력값입니다.")
         String username,
-        @NotNull(message = "비밀번호는 필수입니다.")
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         String password
 ) {
     public LoginUserCommand toCommand() {

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/RegisterUserRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/RegisterUserRequest.java
@@ -2,23 +2,24 @@ package com.oneultanda.userservice.presentation.dto.request;
 
 import com.oneultanda.userservice.application.dto.comand.RegisterUserCommand;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public record RegisterUserRequest(
-        @NotNull(message = "계정명은 필수입니다.")
+        @NotBlank(message = "계정명은 필수 입력값입니다.")
         String username,
 
-        @NotNull(message = "비밀번호는 필수입니다.")
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         String password,
 
-        @NotNull(message = "닉네임은 필수입니다.")
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
         String nickname,
 
         @Email(message = "유효한 이메일 주소를 입력하세요.")
         String email,
 
-        @NotNull(message = "연락처는 필수입니다.")
+        @NotBlank(message = "연락처는 필수 입력값입니다.")
         @Pattern(
                 regexp = "^(01[0-9]-\\d{3,4}-\\d{4})$|^(0\\d{1,2}-\\d{3,4}-\\d{4})$",
                 message = "올바른 전화번호 형식을 입력하세요. 예: 010-1234-5678 또는 02-123-4567"

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/RegisterUserRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/RegisterUserRequest.java
@@ -3,7 +3,6 @@ package com.oneultanda.userservice.presentation.dto.request;
 import com.oneultanda.userservice.application.dto.comand.RegisterUserCommand;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public record RegisterUserRequest(

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/UpdatePasswordRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/UpdatePasswordRequest.java
@@ -1,9 +1,13 @@
 package com.oneultanda.userservice.presentation.dto.request;
 
 import com.oneultanda.userservice.application.dto.comand.UpdatePasswordCommand;
+import jakarta.validation.constraints.NotBlank;
 
 public record UpdatePasswordRequest(
+        @NotBlank(message = "현재 비밀번호는 필수 입력값입니다.")
         String currentPassword,
+
+        @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
         String newPassword
 ) {
     public UpdatePasswordCommand toCommand() {

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/UpdateUserRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/UpdateUserRequest.java
@@ -1,10 +1,21 @@
 package com.oneultanda.userservice.presentation.dto.request;
 
 import com.oneultanda.userservice.application.dto.comand.UpdateUserCommand;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record UpdateUserRequest(
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
         String nickname,
+
+        @Email(message = "유효한 이메일 주소를 입력하세요.")
         String email,
+
+        @Pattern(
+                regexp = "^(01[0-9]-\\d{3,4}-\\d{4})$|^(0\\d{1,2}-\\d{3,4}-\\d{4})$",
+                message = "올바른 전화번호 형식을 입력하세요. 예: 010-1234-5678 또는 02-123-4567"
+        )
         String contact
 ) {
     public UpdateUserCommand toCommand() {

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/UpdateUserRoleRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/UpdateUserRoleRequest.java
@@ -1,9 +1,8 @@
 package com.oneultanda.userservice.presentation.dto.request;
 
 import com.oneultanda.userservice.application.dto.comand.UpdateUserRoleCommand;
-import com.oneultanda.userservice.common.exception.ValidRole;
+import com.oneultanda.userservice.common.validation.ValidRole;
 import com.oneultanda.userservice.domain.model.Role;
-import jakarta.validation.constraints.NotBlank;
 
 public record UpdateUserRoleRequest(
 

--- a/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/UpdateUserRoleRequest.java
+++ b/user-service/src/main/java/com/oneultanda/userservice/presentation/dto/request/UpdateUserRoleRequest.java
@@ -1,9 +1,13 @@
 package com.oneultanda.userservice.presentation.dto.request;
 
 import com.oneultanda.userservice.application.dto.comand.UpdateUserRoleCommand;
+import com.oneultanda.userservice.common.exception.ValidRole;
 import com.oneultanda.userservice.domain.model.Role;
+import jakarta.validation.constraints.NotBlank;
 
 public record UpdateUserRoleRequest(
+
+        @ValidRole(enumClass = Role.class)
         Role role
 ) {
     public UpdateUserRoleCommand toCommand() {

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
 
 
 server:
-  port: 19093
+  port: 19092
 
 eureka:
   client:

--- a/user-service/src/test/http/user.http
+++ b/user-service/src/test/http/user.http
@@ -1,5 +1,5 @@
 ### 유저 생성 - internal
-POST http://localhost:19093/api/v1/users/signup
+POST http://localhost:19092/api/v1/users/signup
 Content-Type: application/json
 
 {
@@ -11,7 +11,7 @@ Content-Type: application/json
 }
 
 ### 로그인
-POST http://localhost:19093/api/v1/users/login
+POST http://localhost:19092/api/v1/users/login
 Content-Type: application/json
 
 {
@@ -27,7 +27,7 @@ X-User-Role: CUSTOMER
 X-User-ID: b3e4849f-69e8-4354-b166-552e05ec81a3
 
 ### 유저 정보 수정
-PUT http://localhost:19093/api/v1/users/me
+PUT http://localhost:19092/api/v1/users/me
 Content-Type: application/json
 X-User-Name: tester
 X-User-Role: CUSTOMER
@@ -52,7 +52,7 @@ X-User-ID: b3e4849f-69e8-4354-b166-552e05ec81a3
 }
 
 ### 유저 탈퇴 todo: 추후 feignclient grpc를 통해 수정 작업 진행
-DELETE http://localhost:19093/api/v1/users/me
+DELETE http://localhost:19092/api/v1/users/me
 Content-Type: application/json
 X-User-Name: tester
 X-User-Role: CUSTOMER
@@ -63,14 +63,14 @@ X-User-ID: b862cf8b-46cd-4b24-9d01-08426466692f
 }
 
 ### 유저 조회 username기반
-GET http://localhost:19093/api/v1/users/admin/tester
+GET http://localhost:19092/api/v1/users/admin/tester
 Content-Type: application/json
 X-User-Name: admin
 X-User-Role: ADMIN
 X-User-ID: b862cf8b-46cd-4b24-9d01-08426466692f
 
 ### 유저 권한 상승 username기반
-PUT http://localhost:19093/api/v1/users/admin/tester
+PUT http://localhost:19092/api/v1/users/admin/tester
 Content-Type: application/json
 X-User-Name: admin
 X-User-Role: ADMIN
@@ -81,7 +81,7 @@ X-User-ID: b862cf8b-46cd-4b24-9d01-08426466692f
 }
 
 ### 유저 조회 userId기반
-GET http://localhost:19093/api/v1/users/4728aa0c-2277-4d1c-89a8-b5b28ec32472
+GET http://localhost:19092/internal/v1/users/09a6b989-86e0-4244-a120-683aef98a599
 Content-Type: application/json
 
 


### PR DESCRIPTION
## 💡 이슈
resolve #84 

## 🤩 개요
user dto validation, error handling, gateway authorization filter non-authorize path

## 🧑‍💻 작업 사항
user dto의 validation 적용, role에는 custom validator 작성
각 에러에 대한 좀더 상세한 정보를 담은 error code, message 작성,
gateway의 토큰없이 통과해야될 경로 들에 대한 수정, 추가

## 📖 참고 사항
내부에서 feign client용도로만 사용되는 경로들에 대한 외부 접근 차단 및, feign client 간의 통신시 용이성을 위해
내, 외부 공동으로 쓰이는 flight의 조회의 경우에는 토큰검증없이 통과, feign client 통신시에도 별다른 header 없이 통신 가능하도록 하였고, 그외 순수하게 내부용으로만 쓰일 통신들은 endpoint를 internal/v1/flight 와 같은 형식으로 하여 gateway route에 등록 하지 않음으로서 외부에서 접근할 수 없도록 하였습니다.
