### PR TITLE
Feat/#89 feat payment service save card info

### DIFF
--- a/payment-service/src/main/java/com/sparta/paymentservice/application/dto/PaymentRequestDto.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/application/dto/PaymentRequestDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -11,5 +12,5 @@ import java.util.UUID;
 @AllArgsConstructor
 public class PaymentRequestDto {
     private UUID reservationId;
-    private Integer totalPrice;
+    private BigDecimal totalPrice;
 }

--- a/payment-service/src/main/java/com/sparta/paymentservice/application/dto/PaymentResponseDto.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/application/dto/PaymentResponseDto.java
@@ -1,10 +1,13 @@
 package com.sparta.paymentservice.application.dto;
 
+import com.siot.IamportRestClient.response.Payment;
+import com.sparta.paymentservice.domain.entity.Payments;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -14,6 +17,22 @@ import java.util.UUID;
 public class PaymentResponseDto {
     private UUID reservationId;
     private String paymentId;
-    private Integer totalPrice;
+    private BigDecimal totalPrice;
     private String status;
+
+    public static PaymentResponseDto toDto(Payment payment) {
+        return PaymentResponseDto.builder()
+                .paymentId(payment.getImpUid())
+                .reservationId(UUID.fromString(payment.getMerchantUid()))
+                .totalPrice(payment.getAmount())
+                .status(payment.getStatus())
+                .build();
+    }
+    public Payments toEntity() {
+        return Payments.create(
+                this.reservationId,
+                this.totalPrice,
+                this.status
+        );
+    }
 }

--- a/payment-service/src/main/java/com/sparta/paymentservice/application/service/ImPortPaymentService.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/application/service/ImPortPaymentService.java
@@ -37,6 +37,10 @@ public class ImPortPaymentService implements PaymentService {
             IamportResponse<Payment> response = iamportClient.onetimePayment(onetimePaymentData);
             Payment payment = response.getResponse();
 
+            if(payment == null) {
+              throw new IllegalArgumentException("결제 실패: " + response.getMessage());
+            }
+
             PaymentResponseDto responseDto = PaymentResponseDto.toDto(payment);
             // 결제 기록 저장
             paymentRepository.save(responseDto.toEntity());

--- a/payment-service/src/main/java/com/sparta/paymentservice/application/service/ImPortPaymentService.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/application/service/ImPortPaymentService.java
@@ -9,32 +9,27 @@ import com.siot.IamportRestClient.response.IamportResponse;
 import com.siot.IamportRestClient.response.Payment;
 import com.sparta.paymentservice.application.dto.PaymentRequestDto;
 import com.sparta.paymentservice.application.dto.PaymentResponseDto;
+import com.sparta.paymentservice.domain.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ImPortPaymentService implements PaymentService {
     private final IamportClient iamportClient;
+    private final PaymentRepository paymentRepository;
 
     @Override
-    public PaymentResponseDto confirmPayment(PaymentRequestDto request) {
+    public PaymentResponseDto confirmPayment(PaymentRequestDto request, CardInfo card) {
         try {
             // 테스트용 결제 정보 설정
             String merchantUid = request.getReservationId().toString();
-            BigDecimal totalPrice = new BigDecimal(request.getTotalPrice());
-
-            String card_number = "5388-1500-0000-0000";
-            String expiry = "2025-12";
-            String birth = "700101";
-            String pwd_2digit = "11";
-            CardInfo card = new CardInfo(card_number, expiry, birth, pwd_2digit);
+            BigDecimal totalPrice = request.getTotalPrice();
 
             OnetimePaymentData onetimePaymentData = new OnetimePaymentData(merchantUid, totalPrice, card);
             onetimePaymentData.setPg("kcp");
@@ -42,12 +37,10 @@ public class ImPortPaymentService implements PaymentService {
             IamportResponse<Payment> response = iamportClient.onetimePayment(onetimePaymentData);
             Payment payment = response.getResponse();
 
-            return PaymentResponseDto.builder()
-                    .paymentId(payment.getImpUid())
-                    .reservationId(UUID.fromString(payment.getMerchantUid()))
-                    .totalPrice(payment.getAmount().intValue())
-                    .status(payment.getStatus())
-                    .build();
+            PaymentResponseDto responseDto = PaymentResponseDto.toDto(payment);
+            // 결제 기록 저장
+            paymentRepository.save(responseDto.toEntity());
+            return responseDto;
 
         } catch (IamportResponseException | IOException e) {
             throw new RuntimeException("결제 처리 중 오류 발생", e);

--- a/payment-service/src/main/java/com/sparta/paymentservice/application/service/KcpPaymentService.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/application/service/KcpPaymentService.java
@@ -20,7 +20,7 @@ import java.math.BigDecimal;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ImPortPaymentService implements PaymentService {
+public class KcpPaymentService implements PaymentService {
     private final IamportClient iamportClient;
     private final PaymentRepository paymentRepository;
 

--- a/payment-service/src/main/java/com/sparta/paymentservice/application/service/PaymentService.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/application/service/PaymentService.java
@@ -1,8 +1,9 @@
 package com.sparta.paymentservice.application.service;
 
+import com.siot.IamportRestClient.request.CardInfo;
 import com.sparta.paymentservice.application.dto.PaymentRequestDto;
 import com.sparta.paymentservice.application.dto.PaymentResponseDto;
 
 public interface PaymentService {
-    PaymentResponseDto confirmPayment(PaymentRequestDto request);
+    PaymentResponseDto confirmPayment(PaymentRequestDto request, CardInfo card);
 }

--- a/payment-service/src/main/java/com/sparta/paymentservice/common/util/TestCardInfo.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/common/util/TestCardInfo.java
@@ -1,0 +1,24 @@
+package com.sparta.paymentservice.common.util;
+
+import com.siot.IamportRestClient.request.CardInfo;
+
+public class TestCardInfo {
+    public static CardInfo testCard1() {
+        return new CardInfo(
+                "5388-1500-0000-0000",
+                "2025-12",
+                "700101",
+                "11"
+        );
+    }
+
+    public static CardInfo testCard2() {
+        return new CardInfo(
+                "1234-0000-0000-0000",
+                "2020-01",
+                "990101",
+                "00"
+        );
+    }
+
+}

--- a/payment-service/src/main/java/com/sparta/paymentservice/domain/entity/Payments.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/domain/entity/Payments.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Entity
@@ -22,13 +23,16 @@ public class Payments {
     private UUID reservationId;
 
     @Column(nullable = false)
-    private Integer totalPrice;
+    private BigDecimal totalPrice;
 
+    @Column(nullable = false)
+    private String status;
 
-    public static Payments create(Integer totalPrice, UUID reservationId) {
+    public static Payments create(UUID reservationId, BigDecimal totalPrice, String status) {
         return Payments.builder()
-                .totalPrice(totalPrice)
                 .reservationId(reservationId)
+                .totalPrice(totalPrice)
+                .status(status)
                 .build();
     }
 }

--- a/payment-service/src/main/java/com/sparta/paymentservice/domain/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/domain/repository/PaymentRepository.java
@@ -1,5 +1,7 @@
 package com.sparta.paymentservice.domain.repository;
 
-public interface PaymentRepository {
+import com.sparta.paymentservice.domain.entity.Payments;
 
+public interface PaymentRepository {
+    void save(Payments payments);
 }

--- a/payment-service/src/main/java/com/sparta/paymentservice/domain/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/domain/repository/PaymentRepository.java
@@ -3,5 +3,5 @@ package com.sparta.paymentservice.domain.repository;
 import com.sparta.paymentservice.domain.entity.Payments;
 
 public interface PaymentRepository {
-    void save(Payments payments);
+    Payments save(Payments payments);
 }

--- a/payment-service/src/main/java/com/sparta/paymentservice/web/PaymentController.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/web/PaymentController.java
@@ -3,23 +3,26 @@ package com.sparta.paymentservice.web;
 import com.siot.IamportRestClient.request.CardInfo;
 import com.sparta.paymentservice.application.dto.PaymentRequestDto;
 import com.sparta.paymentservice.application.dto.PaymentResponseDto;
-import com.sparta.paymentservice.application.service.KcpPaymentService;
+import com.sparta.paymentservice.application.service.PaymentService;
 import com.sparta.paymentservice.common.util.TestCardInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
 public class PaymentController {
-    private final KcpPaymentService kcpPaymentService;
+    private final PaymentService paymentService;
 
     @PostMapping("/confirm")
     public ResponseEntity<PaymentResponseDto> confirmPayment(@RequestBody PaymentRequestDto request) {
         CardInfo card = TestCardInfo.testCard1();
-        PaymentResponseDto response = kcpPaymentService.confirmPayment(request, card);
+        PaymentResponseDto response = paymentService.confirmPayment(request, card);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/payment-service/src/main/java/com/sparta/paymentservice/web/PaymentController.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/web/PaymentController.java
@@ -3,25 +3,23 @@ package com.sparta.paymentservice.web;
 import com.siot.IamportRestClient.request.CardInfo;
 import com.sparta.paymentservice.application.dto.PaymentRequestDto;
 import com.sparta.paymentservice.application.dto.PaymentResponseDto;
-import com.sparta.paymentservice.application.service.ImPortPaymentService;
+import com.sparta.paymentservice.application.service.KcpPaymentService;
 import com.sparta.paymentservice.common.util.TestCardInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
 public class PaymentController {
-    private final ImPortPaymentService imPortPaymentService;
+    private final KcpPaymentService kcpPaymentService;
 
     @PostMapping("/test")
     public ResponseEntity<PaymentResponseDto> confirmPayment(@RequestBody PaymentRequestDto request) {
         CardInfo card = TestCardInfo.testCard1();
-        PaymentResponseDto response = imPortPaymentService.confirmPayment(request, card);
+        PaymentResponseDto response = kcpPaymentService.confirmPayment(request, card);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/payment-service/src/main/java/com/sparta/paymentservice/web/PaymentController.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/web/PaymentController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class PaymentController {
     private final KcpPaymentService kcpPaymentService;
 
-    @PostMapping("/test")
+    @PostMapping("/confirm")
     public ResponseEntity<PaymentResponseDto> confirmPayment(@RequestBody PaymentRequestDto request) {
         CardInfo card = TestCardInfo.testCard1();
         PaymentResponseDto response = kcpPaymentService.confirmPayment(request, card);

--- a/payment-service/src/main/java/com/sparta/paymentservice/web/PaymentController.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/web/PaymentController.java
@@ -1,8 +1,10 @@
 package com.sparta.paymentservice.web;
 
+import com.siot.IamportRestClient.request.CardInfo;
 import com.sparta.paymentservice.application.dto.PaymentRequestDto;
 import com.sparta.paymentservice.application.dto.PaymentResponseDto;
 import com.sparta.paymentservice.application.service.ImPortPaymentService;
+import com.sparta.paymentservice.common.util.TestCardInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,10 +19,10 @@ public class PaymentController {
     private final ImPortPaymentService imPortPaymentService;
 
     @PostMapping("/test")
-    public ResponseEntity<PaymentResponseDto> requestTestPayment(@RequestBody PaymentRequestDto request) {
+    public ResponseEntity<PaymentResponseDto> confirmPayment(@RequestBody PaymentRequestDto request) {
+        CardInfo card = TestCardInfo.testCard1();
+        PaymentResponseDto response = imPortPaymentService.confirmPayment(request, card);
 
-     PaymentResponseDto response = imPortPaymentService.confirmPayment(request);
-
-     return new ResponseEntity<>(response, HttpStatus.OK);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }


### PR DESCRIPTION
## 💡 이슈
resolve #89 

## 🤩 개요
결제시 테스트 카드 정보를 서비스에서 하드코딩하지 않고 정적 클래스로 분리해 필요한 테스트 카드를 골라서 사용할 수 있습니다. 
## 🧑‍💻 작업 사항
테스트 카드 정보 정적 클래스 분리 및 결제시 결제 기록 DB 저장

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
