### PR TITLE
Feat/#88 flight-service GlobalExceptionHandler을 통한 예외처리

### DIFF
--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airline/AirlineExternalService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airline/AirlineExternalService.java
@@ -4,6 +4,8 @@ import com.amadeus.Amadeus;
 import com.amadeus.Params;
 import com.amadeus.resources.Airline;
 import com.oneul_tanda.flight_service.domain.entity.AirlineEntity;
+import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
 import com.oneul_tanda.flight_service.domain.repository.airline.AirlineRepository;
 import com.oneul_tanda.flight_service.presentation.dtos.airline.AirlineResponse;
 import com.oneul_tanda.flight_service.presentation.dtos.airline.AirlineSearchResponse;
@@ -12,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -23,46 +26,54 @@ public class AirlineExternalService {
     private final AirlineRepository airlineRepository;
 
     // 실시간 항공사 정보 조회
-    public List<AirlineSearchResponse> searchAirlines(String keyword, String userRole) throws Exception {
+    public List<AirlineSearchResponse> searchAirlines(String keyword, String userRole) {
         validateUserRole(userRole);
 
-        Airline[] amadeusAirlines = amadeus.referenceData.airlines
-                .get(Params.with("airlineCodes", keyword));
+        try {
+            Airline[] amadeusAirlines = amadeus.referenceData.airlines
+                    .get(Params.with("airlineCodes", keyword));
 
-        return Arrays.stream(amadeusAirlines)
-                .map(amadeusAirline -> new AirlineSearchResponse(
-                        amadeusAirline.getIataCode(),
-                        amadeusAirline.getCommonName()))
-                .collect(Collectors.toList());
+            return Arrays.stream(amadeusAirlines)
+                    .map(amadeusAirline -> new AirlineSearchResponse(
+                            amadeusAirline.getIataCode(),
+                            amadeusAirline.getCommonName()))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("Error while searching airlines: {}", e.getMessage());
+            throw new GlobalException(HttpStatus.BAD_GATEWAY, ErrorMessage.EXTERNAL_API_ERROR);
+        }
     }
 
     // 실시간 항공사 정보 조회 및 DB 저장
-    public List<AirlineResponse> searchAndSaveAirlines(String keyword, String userRole) throws Exception {
+    public List<AirlineResponse> fetchAndSaveAirlines(String keyword, String userRole) {
         validateUserRole(userRole);
 
-        Airline[] amadeusAirlines = amadeus.referenceData.airlines
-                .get(Params.with("airlineCodes", keyword));
+        try {
+            Airline[] amadeusAirlines = amadeus.referenceData.airlines
+                    .get(Params.with("airlineCodes", keyword));
 
-        return Arrays.stream(amadeusAirlines)
-                .map(amadeusAirline -> {
-                    String code = amadeusAirline.getIataCode(); // IATA 코드
-                    String name = amadeusAirline.getCommonName(); // 항공사 이름
+            return Arrays.stream(amadeusAirlines)
+                    .map(amadeusAirline -> {
+                        String code = amadeusAirline.getIataCode(); // IATA 코드
+                        String name = amadeusAirline.getCommonName(); // 항공사 이름
 
-                    // 중복된 항공사는 저장하지 않음
-                    AirlineEntity existingAirline = airlineRepository.findByCode(code).orElseGet(() -> {
-                        AirlineEntity newAirline = AirlineEntity.from(
-                                code, name);
-                        return airlineRepository.save(newAirline);
-                    });
-
-                    return AirlineResponse.from(existingAirline);
-                })
-                .toList();
+                        // 중복된 항공사는 저장하지 않음
+                        AirlineEntity existingAirline = airlineRepository.findByCode(code).orElseGet(() -> {
+                            AirlineEntity newAirline = AirlineEntity.from(code, name);
+                            return airlineRepository.save(newAirline);
+                        });
+                        return AirlineResponse.from(existingAirline);
+                    })
+                    .toList();
+        } catch (Exception e) {
+            log.error("Error while searching and saving airlines: {}", e.getMessage());
+            throw new GlobalException(HttpStatus.BAD_GATEWAY, ErrorMessage.EXTERNAL_API_ERROR);
+        }
     }
 
     private void validateUserRole(String userRole) {
-        if(userRole.equals("CUSTOMER")) {
-            throw new IllegalArgumentException("Access denied");
+        if (userRole.equals("CUSTOMER")) {
+            throw new GlobalException(HttpStatus.FORBIDDEN, ErrorMessage.ACCESS_DENIED);
         }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airline/AirlineService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airline/AirlineService.java
@@ -3,6 +3,10 @@ package com.oneul_tanda.flight_service.application.service.airline;
 import com.oneul_tanda.flight_service.application.dtos.airline.CreateAirlineCommand;
 import com.oneul_tanda.flight_service.application.dtos.airline.UpdateAirlineCommand;
 import com.oneul_tanda.flight_service.domain.entity.AirlineEntity;
+import com.oneul_tanda.flight_service.domain.exception.airline.AirlineDuplicatedException;
+import com.oneul_tanda.flight_service.domain.exception.airline.AirlineNotFoundException;
+import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
 import com.oneul_tanda.flight_service.domain.repository.airline.AirlineRepository;
 import com.oneul_tanda.flight_service.presentation.dtos.airline.AirlineResponse;
 import com.oneul_tanda.flight_service.util.PagingUtil;
@@ -12,6 +16,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,20 +91,19 @@ public class AirlineService {
     }
 
     private AirlineEntity getAirlineById(UUID airlineId) {
-        AirlineEntity airline = airlineRepository.findById(airlineId)
-                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
-        return airline;
+        return airlineRepository.findById(airlineId)
+                .orElseThrow(AirlineNotFoundException::new);
     }
 
     private void getAirlineByCode(CreateAirlineCommand airlineCommand) {
         if (airlineRepository.findByCode(airlineCommand.getCode()).isPresent()) {
-            throw new IllegalArgumentException("Airline code " + airlineCommand.getCode() + " already exists");
+            throw new AirlineDuplicatedException();
         }
     }
 
     private void validateUserRole(String userRole) {
-        if(userRole.equals("CUSTOMER")){
-            throw new IllegalArgumentException("Access denied");
+        if (userRole.equals("CUSTOMER")) {
+            throw new GlobalException(HttpStatus.FORBIDDEN, ErrorMessage.ACCESS_DENIED);
         }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airport/AirportExternalService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airport/AirportExternalService.java
@@ -4,12 +4,15 @@ import com.amadeus.Amadeus;
 import com.amadeus.Params;
 import com.amadeus.resources.Location;
 import com.oneul_tanda.flight_service.domain.entity.AirportEntity;
+import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
 import com.oneul_tanda.flight_service.domain.repository.airport.AirportRepository;
 import com.oneul_tanda.flight_service.presentation.dtos.airport.AirportResponse;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -21,45 +24,54 @@ public class AirportExternalService {
     private final AirportRepository airportRepository;
 
     // 실시간 공항 정보 조회
-    public Location[] searchAirports(String keyword, String userRole) throws Exception {
+    public Location[] searchAirports(String keyword, String userRole) {
         validateUserRole(userRole);
 
-        return amadeus.referenceData.locations.get(
-                Params.with("subType", "AIRPORT")
-                        .and("keyword", keyword)
-                        .and("page[limit]", "10")
-                        .and("sort", "analytics.travelers.score"));
+        try {
+            return amadeus.referenceData.locations.get(
+                    Params.with("subType", "AIRPORT")
+                            .and("keyword", keyword)
+                            .and("page[limit]", "10")
+                            .and("sort", "analytics.travelers.score"));
+        } catch (Exception e) {
+            log.error("Error while searching airports: {}", e.getMessage());
+            throw new GlobalException(HttpStatus.BAD_GATEWAY, ErrorMessage.EXTERNAL_API_ERROR);
+        }
     }
 
     // 실시간 공항 정보 조회 및 DB 저장
-    public List<AirportResponse> searchAndSaveAirports(String keyword, String userRole) throws Exception {
+    public List<AirportResponse> fetchAndSaveAirports(String keyword, String userRole) {
         validateUserRole(userRole);
 
-        Location[] locations = amadeus.referenceData.locations
-                .get(Params.with("keyword", keyword).and("subType", "AIRPORT"));
+        try {
+            Location[] locations = amadeus.referenceData.locations
+                    .get(Params.with("keyword", keyword).and("subType", "AIRPORT"));
 
-        return Arrays.stream(locations)
-                .map(location -> {
-                    String code = location.getIataCode();
+            return Arrays.stream(locations)
+                    .map(location -> {
+                        String code = location.getIataCode();
 
-                    // 중복된 공항은 저장하지 않음
-                    AirportEntity airport = airportRepository.findByCode(code).orElseGet(() -> {
-                        AirportEntity newAirport = AirportEntity.from(
-                                code,
-                                location.getName(),
-                                location.getAddress().getCityName(),
-                                location.getAddress().getCountryName());
-                        return airportRepository.save(newAirport);
-                    });
-
-                    return AirportResponse.from(airport);
-                })
-                .toList();
+                        // 중복된 공항은 저장하지 않음
+                        AirportEntity airport = airportRepository.findByCode(code).orElseGet(() -> {
+                            AirportEntity newAirport = AirportEntity.from(
+                                    code,
+                                    location.getName(),
+                                    location.getAddress().getCityName(),
+                                    location.getAddress().getCountryName());
+                            return airportRepository.save(newAirport);
+                        });
+                        return AirportResponse.from(airport);
+                    })
+                    .toList();
+        } catch (Exception e) {
+            log.error("Error while searching and saving airports: {}", e.getMessage());
+            throw new GlobalException(HttpStatus.BAD_GATEWAY, ErrorMessage.EXTERNAL_API_ERROR);
+        }
     }
 
     private void validateUserRole(String userRole) {
-        if(userRole.equals("CUSTOMER")) {
-            throw new IllegalArgumentException("Access denied");
+        if (userRole.equals("CUSTOMER")) {
+            throw new GlobalException(HttpStatus.FORBIDDEN, ErrorMessage.ACCESS_DENIED);
         }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airport/AirportService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/airport/AirportService.java
@@ -3,6 +3,10 @@ package com.oneul_tanda.flight_service.application.service.airport;
 import com.oneul_tanda.flight_service.application.dtos.airport.CreateAirportCommand;
 import com.oneul_tanda.flight_service.application.dtos.airport.UpdateAirportCommand;
 import com.oneul_tanda.flight_service.domain.entity.AirportEntity;
+import com.oneul_tanda.flight_service.domain.exception.airport.AirportDuplicatedException;
+import com.oneul_tanda.flight_service.domain.exception.airport.AirportNotFoundException;
+import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
 import com.oneul_tanda.flight_service.domain.repository.airport.AirportRepository;
 import com.oneul_tanda.flight_service.domain.repository.airport.AirportRepositoryCustom;
 import com.oneul_tanda.flight_service.presentation.dtos.airport.AirportResponse;
@@ -13,6 +17,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,20 +96,20 @@ public class AirportService {
         airport.updateDeletionInfo(userId);
     }
 
-    private void getAirportByCode(CreateAirportCommand airportCommand) {
-        if (airportRepository.findByCode(airportCommand.getCode()).isPresent()) {
-            throw new IllegalArgumentException("Airport code " + airportCommand.getCode() + " already exists");
-        }
-    }
-
     private AirportEntity getAirportById(UUID airportId) {
         return airportRepository.findById(airportId)
-                .orElseThrow(() -> new IllegalArgumentException("Airport not found"));
+                .orElseThrow(AirportNotFoundException::new);
+    }
+
+    private void getAirportByCode(CreateAirportCommand airportCommand) {
+        if (airportRepository.findByCode(airportCommand.getCode()).isPresent()) {
+            throw new AirportDuplicatedException();
+        }
     }
 
     private void validateUserRole(String userRole) {
         if (userRole.equals("CUSTOMER")) {
-            throw new IllegalArgumentException("Access denied");
+            throw new GlobalException(HttpStatus.FORBIDDEN, ErrorMessage.ACCESS_DENIED);
         }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightExternalService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightExternalService.java
@@ -6,6 +6,9 @@ import com.amadeus.resources.FlightOfferSearch;
 import com.oneul_tanda.flight_service.domain.entity.AirlineEntity;
 import com.oneul_tanda.flight_service.domain.entity.AirportEntity;
 import com.oneul_tanda.flight_service.domain.entity.FlightEntity;
+import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import com.oneul_tanda.flight_service.domain.exception.common.InvalidRequestException;
 import com.oneul_tanda.flight_service.domain.repository.airline.AirlineRepository;
 import com.oneul_tanda.flight_service.domain.repository.airport.AirportRepository;
 import com.oneul_tanda.flight_service.domain.repository.flight.FlightRepository;
@@ -22,6 +25,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -38,42 +42,61 @@ public class FlightExternalService {
     @Cacheable(value = "flightOffers",
             key = "#departureAirportCode + '#' + #arrivalAirportCode + '#' + #departureDate.toLocalDate().toString() + '#' + #requiredSeats")
     public List<FlightResponse> searchFlights(String departureAirportCode, String arrivalAirportCode,
-                                              LocalDateTime departureDate, Integer requiredSeats, String userRole) throws Exception {
+                                              LocalDateTime departureDate, Integer requiredSeats, String userRole
+    ) {
         validateUserRole(userRole);
-        // 과거 날짜 검증
+        // 과거 날짜 검증(검색하고 있는 현재 시점보다 과거일 경우 예외 발생)
         checkDepartureDateInPast(departureDate);
-
+        // 입력값 검증
         validateInputs(departureDate, requiredSeats);
 
-        FlightOfferSearch[] offers = fetchFlightOffers(departureAirportCode, arrivalAirportCode,
-                departureDate.toLocalDate().toString(), requiredSeats);
-        return extractFlightResponses(offers, false);
+        try {
+            FlightOfferSearch[] offers = fetchFlightOffers(departureAirportCode, arrivalAirportCode,
+                    departureDate.toLocalDate().toString(), requiredSeats);
+            return extractFlightResponses(offers, false);
+        } catch (Exception e) {
+            log.error("Error while searching flights: {}", e.getMessage());
+            throw new GlobalException(HttpStatus.BAD_GATEWAY, ErrorMessage.EXTERNAL_API_ERROR);
+        }
     }
 
     @Cacheable(value = "flightOffers",
             key = "#departureAirportCode + '#' + #arrivalAirportCode + '#' + #departureDate.toLocalDate().toString() + '#' + #requiredSeats")
-    public List<FlightResponse> searchAndSaveFlights(String departureAirportCode, String arrivalAirportCode,
-                                                     LocalDateTime departureDate, Integer requiredSeats) throws Exception {
-        // 과거 날짜 검증
+    public List<FlightResponse> fetchAndSaveFlights(
+            String departureAirportCode, String arrivalAirportCode,
+            LocalDateTime departureDate, Integer requiredSeats
+    ) {
+        // 과거 날짜 검증(검색하고 있는 현재 시점보다 과거일 경우 예외 발생)
         checkDepartureDateInPast(departureDate);
-
+        // 입력값 검증
         validateInputs(departureDate, requiredSeats);
 
-        FlightOfferSearch[] offers = fetchFlightOffers(departureAirportCode, arrivalAirportCode,
-                departureDate.toLocalDate().toString(), requiredSeats);
-        return extractFlightResponses(offers, true);
+        try {
+            FlightOfferSearch[] offers = fetchFlightOffers(departureAirportCode, arrivalAirportCode,
+                    departureDate.toLocalDate().toString(), requiredSeats);
+            return extractFlightResponses(offers, true);
+        } catch (Exception e) {
+            log.error("Error while searching and saving flights: {}", e.getMessage());
+            throw new GlobalException(HttpStatus.BAD_GATEWAY, ErrorMessage.EXTERNAL_API_ERROR);
+        }
     }
 
-    private FlightOfferSearch[] fetchFlightOffers(String departureAirportCode, String arrivalAirportCode,
-                                                  String departureDate, Integer requiredSeats) throws Exception {
-
-        return amadeus.shopping.flightOffersSearch.get(
-                Params.with("originLocationCode", departureAirportCode)
-                        .and("destinationLocationCode", arrivalAirportCode)
-                        .and("departureDate", departureDate)
-                        .and("adults", requiredSeats)
-                        .and("travelClass", "ECONOMY")
-                        .and("max", 10));
+    private FlightOfferSearch[] fetchFlightOffers(
+            String departureAirportCode, String arrivalAirportCode,
+            String departureDate, Integer requiredSeats
+    ) {
+        try {
+            return amadeus.shopping.flightOffersSearch.get(
+                    Params.with("originLocationCode", departureAirportCode)
+                            .and("destinationLocationCode", arrivalAirportCode)
+                            .and("departureDate", departureDate)
+                            .and("adults", requiredSeats)
+                            .and("travelClass", "ECONOMY")
+                            .and("max", 10));
+        } catch (Exception e) {
+            log.error("Error while fetching flight offers: {}", e.getMessage());
+            throw new GlobalException(HttpStatus.BAD_GATEWAY, ErrorMessage.EXTERNAL_API_ERROR);
+        }
     }
 
     private List<FlightResponse> extractFlightResponses(
@@ -154,7 +177,7 @@ public class FlightExternalService {
     }
 
     private Optional<FlightEntity> getExistingFlight(String flightNum, LocalDateTime departureTime,
-                                                   LocalDateTime arrivalTime) {
+                                                     LocalDateTime arrivalTime) {
         return flightRepository.findByFlightNumAndDepartureDateAndArrivalDate(
                 flightNum, departureTime, arrivalTime);
     }
@@ -166,33 +189,30 @@ public class FlightExternalService {
 
     private AirportEntity getArrivalAirport(String arrivalAirportCode) {
         return airportRepository.findByCode(arrivalAirportCode)
-                .orElseThrow(
-                        () -> new IllegalArgumentException("Invalid arrival airport code: " + arrivalAirportCode));
+                .orElseThrow(InvalidRequestException::new);
     }
 
     private AirportEntity getDepartureAirport(String departureAirportCode) {
         return airportRepository.findByCode(departureAirportCode)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Invalid departure airport code: " + departureAirportCode));
+                .orElseThrow(InvalidRequestException::new);
     }
 
     private void checkDepartureDateInPast(LocalDateTime departureDate) {
         LocalDateTime now = LocalDateTime.now();
         if (departureDate.toLocalDate().isBefore(now.toLocalDate())) {
-            log.warn("Requested departureDate {} is in the past", departureDate);
-            throw new IllegalArgumentException("departureDate cannot be in the past");
+            throw new InvalidRequestException();
         }
     }
 
     private void validateUserRole(String userRole) {
-        if(userRole.equals("CUSTOMER")) {
-            throw new IllegalArgumentException("Access denied");
+        if (userRole.equals("CUSTOMER")) {
+            throw new GlobalException(HttpStatus.FORBIDDEN, ErrorMessage.ACCESS_DENIED);
         }
     }
 
     private void validateInputs(LocalDateTime departureDate, Integer requiredSeats) {
         if (departureDate == null) {
-            throw new IllegalArgumentException("departureDate is required");
+            throw new InvalidRequestException();
         }
         if (requiredSeats == null || requiredSeats <= 0) {
             requiredSeats = 1;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightService.java
@@ -5,6 +5,12 @@ import com.oneul_tanda.flight_service.application.dtos.flight.UpdateFlightComman
 import com.oneul_tanda.flight_service.domain.entity.AirlineEntity;
 import com.oneul_tanda.flight_service.domain.entity.AirportEntity;
 import com.oneul_tanda.flight_service.domain.entity.FlightEntity;
+import com.oneul_tanda.flight_service.domain.exception.airline.AirlineNotFoundException;
+import com.oneul_tanda.flight_service.domain.exception.airport.AirportNotFoundException;
+import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import com.oneul_tanda.flight_service.domain.exception.flight.FlightDuplicatedException;
+import com.oneul_tanda.flight_service.domain.exception.flight.FlightNotFoundException;
 import com.oneul_tanda.flight_service.domain.repository.airline.AirlineRepository;
 import com.oneul_tanda.flight_service.domain.repository.airport.AirportRepository;
 import com.oneul_tanda.flight_service.domain.repository.flight.FlightRepository;
@@ -20,6 +26,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,11 +68,7 @@ public class FlightService {
     public FlightResponse createFlight(CreateFlightCommand flightCommand, UUID userId, String userRole) {
         validateUserRole(userRole);
 
-        if (flightRepository.findByFlightNumAndDepartureDate(flightCommand.getFlightNum(),
-                        flightCommand.getDepartureDate())
-                .isPresent()) {
-            throw new IllegalArgumentException("Flight with this flight number and departure date already exists");
-        }
+        checkFlightDuplicate(flightCommand);
 
         // AirlineEntity와 Airport 엔티티 조회
         AirlineEntity airline = getAirlineForCreateFlight(flightCommand);
@@ -149,42 +152,49 @@ public class FlightService {
 
     private AirportEntity getArrivalAirportForUpdateFlight(UpdateFlightCommand flightCommand) {
         return airportRepository.findByCode(flightCommand.getArrivalAirportCode())
-                .orElseThrow(() -> new IllegalArgumentException("Arrival Airport not found"));
+                .orElseThrow(AirportNotFoundException::new);
     }
 
     private AirportEntity getDepartureAirportForUpdateFlight(UpdateFlightCommand flightCommand) {
         return airportRepository.findByCode(flightCommand.getDepartureAirportCode())
-                .orElseThrow(() -> new IllegalArgumentException("Departure Airport not found"));
-    }
-
-    private AirlineEntity getAirlineForUpdateFlight(UpdateFlightCommand flightCommand) {
-        return airlineRepository.findByCode(flightCommand.getAirlineCode())
-                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
+                .orElseThrow(AirportNotFoundException::new);
     }
 
     private AirportEntity getArrivalAirportForCreateFlight(CreateFlightCommand flightCommand) {
         return airportRepository.findByCode(flightCommand.getArrivalAirportCode())
-                .orElseThrow(() -> new IllegalArgumentException("Arrival Airport not found"));
+                .orElseThrow(AirportNotFoundException::new);
     }
 
     private AirportEntity getDepartureAirportForCreateFlight(CreateFlightCommand flightCommand) {
         return airportRepository.findByCode(flightCommand.getDepartureAirportCode())
-                .orElseThrow(() -> new IllegalArgumentException("Departure Airport not found"));
+                .orElseThrow(AirportNotFoundException::new);
+    }
+
+    private AirlineEntity getAirlineForUpdateFlight(UpdateFlightCommand flightCommand) {
+        return airlineRepository.findByCode(flightCommand.getAirlineCode())
+                .orElseThrow(AirlineNotFoundException::new);
     }
 
     private AirlineEntity getAirlineForCreateFlight(CreateFlightCommand flightCommand) {
         return airlineRepository.findByCode(flightCommand.getAirlineCode())
-                .orElseThrow(() -> new IllegalArgumentException("Airline not found"));
+                .orElseThrow(AirlineNotFoundException::new);
     }
 
     private FlightEntity getFlightById(UUID flightId) {
         return flightRepository.findById(flightId)
-                .orElseThrow(() -> new IllegalArgumentException("Flight not found"));
+                .orElseThrow(FlightNotFoundException::new);
+    }
+
+    private void checkFlightDuplicate(CreateFlightCommand flightCommand) {
+        if (flightRepository.findByFlightNumAndDepartureDate(flightCommand.getFlightNum(),
+                flightCommand.getDepartureDate()).isPresent()) {
+            throw new FlightDuplicatedException();
+        }
     }
 
     private void validateUserRole(String userRole) {
-        if(userRole.equals("CUSTOMER")) {
-            throw new IllegalArgumentException("Access denied");
+        if (userRole.equals("CUSTOMER")) {
+            throw new GlobalException(HttpStatus.FORBIDDEN, ErrorMessage.ACCESS_DENIED);
         }
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/airline/AirlineDuplicatedException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/airline/AirlineDuplicatedException.java
@@ -1,0 +1,10 @@
+package com.oneul_tanda.flight_service.domain.exception.airline;
+
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import org.springframework.dao.DataIntegrityViolationException;
+
+public class AirlineDuplicatedException extends DataIntegrityViolationException {
+    public AirlineDuplicatedException() {
+        super(ErrorMessage.DUPLICATED_AIRLINE.getMessage());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/airline/AirlineNotFoundException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/airline/AirlineNotFoundException.java
@@ -1,0 +1,10 @@
+package com.oneul_tanda.flight_service.domain.exception.airline;
+
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import jakarta.persistence.EntityNotFoundException;
+
+public class AirlineNotFoundException extends EntityNotFoundException {
+    public AirlineNotFoundException() {
+        super(ErrorMessage.AIRLINE_NOT_FOUND.getMessage());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/airport/AirportDuplicatedException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/airport/AirportDuplicatedException.java
@@ -1,0 +1,10 @@
+package com.oneul_tanda.flight_service.domain.exception.airport;
+
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import org.springframework.dao.DataIntegrityViolationException;
+
+public class AirportDuplicatedException extends DataIntegrityViolationException {
+    public AirportDuplicatedException() {
+        super(ErrorMessage.DUPLICATED_AIRPORT.getMessage());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/airport/AirportNotFoundException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/airport/AirportNotFoundException.java
@@ -1,0 +1,10 @@
+package com.oneul_tanda.flight_service.domain.exception.airport;
+
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import jakarta.persistence.EntityNotFoundException;
+
+public class AirportNotFoundException extends EntityNotFoundException {
+    public AirportNotFoundException() {
+        super(ErrorMessage.AIRPORT_NOT_FOUND.getMessage());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/ErrorMessage.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/ErrorMessage.java
@@ -1,0 +1,33 @@
+package com.oneul_tanda.flight_service.domain.exception.common;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorMessage {
+    // 예외 메시지 Enum으로 관리
+
+    // Airline
+    AIRLINE_NOT_FOUND("AIRLINE_NOT_FOUND", "해당 항공사를 찾을 수 없습니다."),
+    DUPLICATED_AIRLINE("DUPLICATED_AIRLINE", "중복된 항공사입니다."),
+
+    // Airport
+    AIRPORT_NOT_FOUND("AIRPORT_NOT_FOUND", "해당 공항을 찾을 수 없습니다."),
+    DUPLICATED_AIRPORT("DUPLICATED_AIRPORT", "중복된 공항입니다."),
+
+    // Flight
+    FLIGHT_NOT_FOUND("FLIGHT_NOT_FOUND", "해당 항공편을 찾을 수 없습니다."),
+    DUPLICATED_FLIGHT("DUPLICATED_FLIGHT", "중복된 항공편입니다."),
+
+    // Common
+    ACCESS_DENIED("ACCESS_DENIED", "접근 권한이 없습니다."),
+    INVALID_REQUEST("INVALID_REQUEST", "잘못된 요청입니다."),
+    EXTERNAL_API_ERROR("EXTERNAL_API_ERROR", "외부 API 호출에 실패했습니다.");
+
+    private final String code;
+    private final String message;
+
+    ErrorMessage(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/ExternalApiException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/ExternalApiException.java
@@ -1,0 +1,7 @@
+package com.oneul_tanda.flight_service.domain.exception.common;
+
+public class ExternalApiException extends RuntimeException {
+    public ExternalApiException() {
+        super(ErrorMessage.EXTERNAL_API_ERROR.getMessage());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/GlobalException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/GlobalException.java
@@ -1,0 +1,17 @@
+package com.oneul_tanda.flight_service.domain.exception.common;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GlobalException extends RuntimeException {
+    // 예외를 처리하기 위한 Custom Exception
+    private final HttpStatus status;
+    private final ErrorMessage errorMessage;
+
+    public GlobalException(HttpStatus status, ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.status = status;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/InvalidRequestException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/InvalidRequestException.java
@@ -1,0 +1,7 @@
+package com.oneul_tanda.flight_service.domain.exception.common;
+
+public class InvalidRequestException extends RuntimeException {
+    public InvalidRequestException() {
+        super(ErrorMessage.INVALID_REQUEST.getMessage());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/flight/FlightDuplicatedException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/flight/FlightDuplicatedException.java
@@ -1,0 +1,10 @@
+package com.oneul_tanda.flight_service.domain.exception.flight;
+
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import org.springframework.dao.DataIntegrityViolationException;
+
+public class FlightDuplicatedException extends DataIntegrityViolationException {
+    public FlightDuplicatedException() {
+        super(ErrorMessage.DUPLICATED_FLIGHT.getMessage());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/flight/FlightNotFoundException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/flight/FlightNotFoundException.java
@@ -1,0 +1,10 @@
+package com.oneul_tanda.flight_service.domain.exception.flight;
+
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import jakarta.persistence.EntityNotFoundException;
+
+public class FlightNotFoundException extends EntityNotFoundException {
+    public FlightNotFoundException() {
+        super(ErrorMessage.FLIGHT_NOT_FOUND.getMessage());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/JpaAuditorAware.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/JpaAuditorAware.java
@@ -3,24 +3,32 @@ package com.oneul_tanda.flight_service.infrastructure.config;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+@Slf4j
 @Component
-public class JpaAuditorAware implements AuditorAware<String> {
+public class JpaAuditorAware implements AuditorAware<UUID> {
 
     @Override
-    public Optional<String> getCurrentAuditor() {
+    public Optional<UUID> getCurrentAuditor() {
         // 현재 요청의 RequestAttributes 를 가져옴
         RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
         if (requestAttributes instanceof ServletRequestAttributes servletRequestAttributes) {
             HttpServletRequest request = servletRequestAttributes.getRequest();
             String userId = request.getHeader("X-User-Id");
-
-            return Optional.ofNullable(userId);
+            try {
+                return Optional.ofNullable(userId)
+                        .map(UUID::fromString); // 명시적으로 변환
+            } catch (IllegalArgumentException e) {
+                // UUID 파싱 실패한 경우
+                log.error("Invalid UUID format: {}", userId, e);
+                return Optional.empty();
+            }
         } else {
             return Optional.empty();
         }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/external/AirlineController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/external/AirlineController.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.presentation.controller;
+package com.oneul_tanda.flight_service.presentation.controller.external;
 
 import com.oneul_tanda.flight_service.application.service.airline.AirlineService;
 import com.oneul_tanda.flight_service.presentation.dtos.airline.AirlineResponse;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/external/AirportController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/external/AirportController.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.presentation.controller;
+package com.oneul_tanda.flight_service.presentation.controller.external;
 
 import com.oneul_tanda.flight_service.application.service.airport.AirportService;
 import com.oneul_tanda.flight_service.presentation.dtos.airport.AirportResponse;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/external/AmadeusController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/external/AmadeusController.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.presentation.controller;
+package com.oneul_tanda.flight_service.presentation.controller.external;
 
 import com.amadeus.resources.Location;
 import com.oneul_tanda.flight_service.application.service.airline.AirlineExternalService;
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,61 +39,44 @@ public class AmadeusController {
     @GetMapping("/airports/live-search")
     public ResponseEntity<List<AirportSearchResponse>> searchAirports(
             @RequestParam String keyword,
-            @RequestHeader ("X-User-Role") String userRole
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        try {
-            Location[] locations = airportExternalService.searchAirports(keyword, userRole);
-            List<AirportSearchResponse> response = Arrays.stream(locations)
-                    .map(AirportSearchResponse::from)
-                    .toList();
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            log.error("Error while searching airports", e);  // 예외 로깅 추가
-            return ResponseEntity.internalServerError().build();  // 서버 오류 상태 코드 반환
-        }
+        Location[] locations = airportExternalService.searchAirports(keyword, userRole);
+        List<AirportSearchResponse> response = Arrays.stream(locations)
+                .map(AirportSearchResponse::from)
+                .toList();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     // 실시간 공항 정보 조회 및 DB 저장용
     @PostMapping("/airports/fetch-and-save")
-    public ResponseEntity<List<AirportResponse>> searchAndSaveAirports(
+    public ResponseEntity<List<AirportResponse>> fetchAndSaveAirports(
             @RequestParam String keyword,
-            @RequestHeader ("X-User-Role") String userRole
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        try {
-            return ResponseEntity.ok(airportExternalService.searchAndSaveAirports(keyword, userRole));
-        } catch (Exception e) {
-            log.error("Error fetching and saving airports: {}", e.getMessage());
-            return ResponseEntity.internalServerError().build();
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(airportExternalService.fetchAndSaveAirports(keyword, userRole));
     }
+
 
     // 실시간 항공사 정보 조회용
     @GetMapping("/airlines/live-search")
     public ResponseEntity<List<AirlineSearchResponse>> searchAirlines(
             @RequestParam String keyword,
-            @RequestHeader ("X-User-Role") String userRole
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        try {
-            List<AirlineSearchResponse> airlineResponses = airlineExternalService.searchAirlines(keyword, userRole);
-            return ResponseEntity.ok(airlineResponses);
-        } catch (Exception e) {
-            log.error("Error while fetching airlines", e);
-            return ResponseEntity.internalServerError().build();
-        }
+        List<AirlineSearchResponse> airlineResponses = airlineExternalService.searchAirlines(keyword, userRole);
+        return ResponseEntity.status(HttpStatus.OK).body(airlineResponses);
     }
 
     // 실시간 항공사 정보 조회 및 DB 저장용
     @PostMapping("/airlines/fetch-and-save")
-    public ResponseEntity<List<AirlineResponse>> searchAndSaveAirlines(
+    public ResponseEntity<List<AirlineResponse>> fetchAndSaveAirlines(
             @RequestParam String keyword,
-            @RequestHeader ("X-User-Role") String userRole
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        try {
-            return ResponseEntity.ok(airlineExternalService.searchAndSaveAirlines(keyword, userRole));
-        } catch (Exception e) {
-            log.error("Error fetching and saving airlines: {}", e.getMessage());
-            return ResponseEntity.internalServerError().build();
-        }
+        List<AirlineResponse> airlineResponses = airlineExternalService.fetchAndSaveAirlines(keyword, userRole);
+        return ResponseEntity.status(HttpStatus.OK).body(airlineResponses);
     }
 
     // 실시간 항공편 정보 조회용
@@ -102,33 +86,23 @@ public class AmadeusController {
             @RequestParam String arrivalAirportCode,
             @RequestParam @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime departureDate,
             @RequestParam Integer requiredSeats,
-            @RequestHeader ("X-User-Role") String userRole
+            @RequestHeader("X-User-Role") String userRole
     ) {
-        try {
-            List<FlightResponse> flightResponses = flightExternalService.searchFlights(
-                    departureAirportCode, arrivalAirportCode, departureDate, requiredSeats, userRole);
-            return ResponseEntity.ok(flightResponses);
-        } catch (Exception e) {
-            log.error("Error while searching flights", e);
-            return ResponseEntity.internalServerError().build();
-        }
+        List<FlightResponse> flightResponses = flightExternalService.searchFlights(
+                departureAirportCode, arrivalAirportCode, departureDate, requiredSeats, userRole);
+        return ResponseEntity.status(HttpStatus.OK).body(flightResponses);
     }
 
     // 실시간 항공편 정보 조회 및 DB 저장용
     @PostMapping("/flights/fetch-and-save")
-    public ResponseEntity<List<FlightResponse>> searchAndSaveFlights(
+    public ResponseEntity<List<FlightResponse>> fetchAndSaveFlights(
             @RequestParam String departureAirportCode,
             @RequestParam String arrivalAirportCode,
             @RequestParam @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime departureDate,
             @RequestParam Integer requiredSeats
     ) {
-        try {
-            List<FlightResponse> response = flightExternalService.searchAndSaveFlights(
-                    departureAirportCode, arrivalAirportCode, departureDate, requiredSeats);
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            log.error("Error while searching and saving flights", e);
-            return ResponseEntity.internalServerError().build();
-        }
+        List<FlightResponse> response = flightExternalService.fetchAndSaveFlights(
+                departureAirportCode, arrivalAirportCode, departureDate, requiredSeats);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/external/FlightController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/external/FlightController.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.presentation.controller;
+package com.oneul_tanda.flight_service.presentation.controller.external;
 
 import com.oneul_tanda.flight_service.application.service.flight.FlightService;
 import com.oneul_tanda.flight_service.presentation.dtos.flight.CreateFlightRequest;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/internal/InternalController.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/controller/internal/InternalController.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.presentation.controller;
+package com.oneul_tanda.flight_service.presentation.controller.internal;
 
 import com.oneul_tanda.flight_service.application.service.flight.FlightService;
 import java.util.UUID;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/dtos/exception/ErrorResponse.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/dtos/exception/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.oneul_tanda.flight_service.presentation.dtos.exception;
+
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    //예외 응답을 일관된 구조로 생성
+    private HttpStatus status;
+    private String code;
+    private String message;
+
+    public static ResponseEntity<ErrorResponse> createResponse(HttpStatus status, ErrorMessage errorMessage) {
+        return ResponseEntity
+                .status(status)
+                .body(new ErrorResponse(status, errorMessage.getCode(), errorMessage.getMessage()));
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/exception/GlobalExceptionHandler.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,90 @@
+package com.oneul_tanda.flight_service.presentation.exception;
+
+import com.oneul_tanda.flight_service.domain.exception.airline.AirlineDuplicatedException;
+import com.oneul_tanda.flight_service.domain.exception.airline.AirlineNotFoundException;
+import com.oneul_tanda.flight_service.domain.exception.airport.AirportDuplicatedException;
+import com.oneul_tanda.flight_service.domain.exception.airport.AirportNotFoundException;
+import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import com.oneul_tanda.flight_service.presentation.dtos.exception.ErrorResponse;
+import com.oneul_tanda.flight_service.domain.exception.common.ExternalApiException;
+import com.oneul_tanda.flight_service.domain.exception.flight.FlightDuplicatedException;
+import com.oneul_tanda.flight_service.domain.exception.flight.FlightNotFoundException;
+import com.oneul_tanda.flight_service.domain.exception.common.InvalidRequestException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(GlobalException e) {
+       log.info("GlobalException: {}", e.getMessage(), e);
+        return ErrorResponse.createResponse(e.getStatus(), e.getErrorMessage());
+    }
+
+    // Airline
+    @ExceptionHandler(AirlineNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleAirlineNotFoundException(AirlineNotFoundException e) {
+        return ErrorResponse.createResponse(HttpStatus.NOT_FOUND, ErrorMessage.AIRLINE_NOT_FOUND);
+    }
+
+    @ExceptionHandler(AirlineDuplicatedException.class)
+    public ResponseEntity<ErrorResponse> handleAirlineDuplicatedException(AirlineDuplicatedException e) {
+        return ErrorResponse.createResponse(HttpStatus.CONFLICT, ErrorMessage.DUPLICATED_AIRLINE);
+    }
+
+    // Airport
+    @ExceptionHandler(AirportNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleAirportNotFoundException(AirportNotFoundException e) {
+        return ErrorResponse.createResponse(HttpStatus.NOT_FOUND, ErrorMessage.AIRPORT_NOT_FOUND);
+    }
+
+    @ExceptionHandler(AirportDuplicatedException.class)
+    public ResponseEntity<ErrorResponse> handleAirportDuplicatedException(AirportDuplicatedException e) {
+        return ErrorResponse.createResponse(HttpStatus.CONFLICT, ErrorMessage.DUPLICATED_AIRPORT);
+    }
+
+    // Flight
+    @ExceptionHandler(FlightNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleFlightNotFoundException(FlightNotFoundException e) {
+        return ErrorResponse.createResponse(HttpStatus.NOT_FOUND, ErrorMessage.FLIGHT_NOT_FOUND);
+    }
+
+    @ExceptionHandler(FlightDuplicatedException.class)
+    public ResponseEntity<ErrorResponse> handleFlightDuplicatedException(FlightDuplicatedException e) {
+        return ErrorResponse.createResponse(HttpStatus.CONFLICT, ErrorMessage.DUPLICATED_FLIGHT);
+    }
+
+    // Common
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRequestException(InvalidRequestException e) {
+        return ErrorResponse.createResponse(HttpStatus.BAD_REQUEST, ErrorMessage.INVALID_REQUEST);
+    }
+
+    @ExceptionHandler(ExternalApiException.class)
+    public ResponseEntity<ErrorResponse> handleExternalApiException(ExternalApiException e) {
+        return ErrorResponse.createResponse(HttpStatus.BAD_GATEWAY, ErrorMessage.EXTERNAL_API_ERROR);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(
+            MethodArgumentNotValidException e) {
+
+        BindingResult bindingResult = e.getBindingResult();
+        Map<String, String> errors = new HashMap<>();
+        bindingResult.getAllErrors()
+                .forEach(c -> errors.put(((FieldError) c).getField(), c.getDefaultMessage()));
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+}


### PR DESCRIPTION
## 💡 이슈
resolve #88 

## 🤩 개요
GlobalExceptionHandler를 통한 예외처리

## 🧑‍💻 작업 사항
- 예외가 발생한 정확한 원인 파악을 위해 도메인별 CustomException 생성
- ErrorMessage 관리 및 확장성 위해 Enum 타입으로 생성
- GlobalExceptionHandler를 사용한 예외처리
- internal과 external 컨트롤러 패키지 분리
- AmadeusController에 있던 예외처리 로직 service로 이동
- JpaAuditAware String -> UUID로 변경

## 📖 참고 사항
