### PR TITLE
Feat/#99 reservation-service 예약 임시 생성/예약 확정 기능 리팩터링

### DIFF
--- a/api-http-test/integration.http
+++ b/api-http-test/integration.http
@@ -1,6 +1,7 @@
 # 전체 시나리오
 # 회원가입 → 로그인 → 특가 항공권 예매 요청 → 예약 대기열 서비스: 좌석 선점 처리 → 예약 대기열 서비스: 좌석 선점 성공 →
-# 예약 대기열 서비스 Kafka prodcuer: 예약 선점 성공 이벤트 발행 → 예약 서비스 Kafka Consumer: 예약 임시 생성 -> 예약 서비스: 추후 예약 확정 진행
+# 예약 대기열 서비스 Kafka prodcuer: 예약 선점 성공 이벤트 발행 → 예약 서비스 Kafka Consumer: 예약 임시 생성 →
+# 예약 서비스: 예약 확정 (탑승객 정보 입력 + 결제 처리)
 
 
 
@@ -46,6 +47,11 @@ Authorization: Bearer {{access_token}}
 }
 
 
+### 예약 대기열 서비스 Kafka prodcuer: 예약 선점 성공 이벤트 발행
+
+### 예약 서비스 Kafka Consumer: 예약 임시 생성
+
+
 ### 예약 단일 조회
 GET http://localhost:19091/api/v1/reservations/9b7f421f-47b0-47f5-aa5c-8f489697a57d
 Content-Type: application/json
@@ -59,14 +65,7 @@ Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 
-### 예약 대기열 서비스 Kafka prodcuer: 예약 선점 성공 이벤트 발행
-
-### 예약 서비스 Kafka Consumer: 예약 임시 생성
-
-
-
-
-### 예약 확정(예약 수정)
+### 예약 확정 V1(예약 수정)
 PUT http://localhost:19091/api/v1/reservations/df4aa5d2-2e7b-4728-a5b7-9cbbe1f7d35d/confirm
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
@@ -92,4 +91,38 @@ Authorization: Bearer {{access_token}}
       }
     }
   ]
+}
+
+
+### 예약 확정 V2
+PUT http://localhost:19091/api/v1/reservations/confirm
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "flightId": "57944490-33fb-4bb1-9254-1eae30a1a25c",
+  "passengers": [
+    {
+      "name": "홍길동1",
+      "birth": "1990-01-01",
+      "gender": "MALE",
+      "passportNumber": "P12345678"
+    },
+    {
+      "name": "홍길동",
+      "birth": "1995-06-10",
+      "gender": "FEMALE",
+      "passportNumber": "P87654321"
+    }
+  ]
+}
+
+
+### 예약 확정 V2, 결제 재시도
+PUT http://localhost:19091/api/v1/reservations/confirm
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "flightId": "57944490-33fb-4bb1-9254-1eae30a1a25c"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,10 +47,10 @@ services:
     container_name: oneultanda-user-db
     restart: always
     environment:
-      - MYSQL_DB_ROOT_PASSWORD=${USER_DB_ROOT_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${USER_DB_ROOT_PASSWORD}
       - MYSQL_DATABASE=user_db
-      - USER_DB_ID=${USER_DB_ID}
-      - USER_DB_PASSWORD=${USER_DB_PASSWORD}
+      - MYSQL_USER=${USER_DB_ID}
+      - MYSQL_PASSWORD=${USER_DB_PASSWORD}
     ports:
       - "3309:3306"
     volumes:
@@ -79,9 +79,9 @@ services:
     image: postgres:16.3
     container_name: oneultanda-flight-db
     environment:
-      - FLIGHT_DB_ID=${FLIGHT_DB_ID}
       - POSTGRES_DB=flight_db
-      - FLIGHT_DB_PASSWORD=${FLIGHT_DB_PASSWORD}
+      - POSTGRES_USER=${FLIGHT_DB_ID}
+      - POSTGRES_PASSWORD=${FLIGHT_DB_PASSWORD}
     ports:
       - "5433:5432"
     volumes:
@@ -108,10 +108,10 @@ services:
     image: mysql:8.0
     container_name: oneultanda-reservation-db
     environment:
-      - MYSQL_DB_ROOT_PASSWORD=${RESERVATION_DB_ROOT_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${RESERVATION_DB_ROOT_PASSWORD}
       - MYSQL_DATABASE=reservation_db
-      - RESERVATION_DB_ID=${RESERVATION_DB_ID}
-      - RESERVATION_DB_PASSWORD=${RESERVATION_DB_PASSWORD}
+      - MYSQL_USER=${RESERVATION_DB_ID}
+      - MYSQL_PASSWORD=${RESERVATION_DB_PASSWORD}
     ports:
       - "3307:3306"
     volumes:
@@ -157,12 +157,12 @@ services:
 
   payments-db:
     image: mysql:8.0
-    container_name: oneultanda-reservation-db
+    container_name: oneultanda-payment-db
     environment:
-      - MYSQL_DB_ROOT_PASSWORD=${PAYMENT_DB_ROOT_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${PAYMENT_DB_ROOT_PASSWORD}
       - MYSQL_DATABASE=payments_db
-      - PAYMENT_DB_USERNAME=${PAYMENT_DB_USERNAME}
-      - PAYMENT_DB_PASSWORD=${PAYMENT_DB_PASSWORD}
+      - MYSQL_USER=${PAYMENT_DB_USERNAME}
+      - MYSQL_PASSWORD=${PAYMENT_DB_PASSWORD}
       - IMPORT_API_KEY=${IMPORT_API_KEY}
       - IMPORT_API_SECRET_KEY=${IMPORT_API_SECRET_KEY}
     ports:

--- a/flight-service/src/main/resources/application.yml
+++ b/flight-service/src/main/resources/application.yml
@@ -8,8 +8,8 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://flight-db:5432/flight_db
-    username: ${"FLIGHT_DB_ID"}
-    password: ${"FLIGHT_DB_PASSWORD"}
+    username: ${FLIGHT_DB_ID}
+    password: ${FLIGHT_DB_PASSWORD}
 
   jpa:
     hibernate:

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -7,8 +7,8 @@ spring:
 
   datasource:
     url: jdbc:mysql://payments-db:3306/payments_db
-    username: ${"PAYMENT_USERNAME"}
-    password: ${"PAYMENT_PASSWORD"}
+    username: ${PAYMENT_DB_USERNAME}
+    password: ${PAYMENT_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -23,6 +23,6 @@ eureka:
 
 import:
   api:
-    key: ${"IMPORT_API_KEY"}
+    key: ${IMPORT_API_KEY}
     secret:
-      key: ${"IMPORT_API_SECRET_KEY"}
+      key: ${IMPORT_API_SECRET_KEY}

--- a/reservation-service/build.gradle
+++ b/reservation-service/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/client/dto/response/CreatePaymentInfo.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/client/dto/response/CreatePaymentInfo.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 public record CreatePaymentInfo(
         UUID id,
-        UUID paymentId,
+        String paymentId,
         BigDecimal totalPrice,
         String status
 ) {

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommandV2.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommandV2.java
@@ -1,0 +1,23 @@
+package com.oneul_tanda.reservation_service.reservation.application.command;
+
+import com.oneul_tanda.reservation_service.reservation.application.dto.PassengerDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDtoV2;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ConfirmReservationCommandV2(
+        UUID userId,
+        UUID flightId,
+        List<PassengerDto> passengers
+) {
+    public static ConfirmReservationCommandV2 of(UUID userId, ConfirmReservationRequestDtoV2 dto) {
+        return new ConfirmReservationCommandV2(
+                userId,
+                dto.flightId(),
+                dto.passengers() == null ? List.of() : dto.passengers().stream()
+                        .map(PassengerDto::from)
+                        .toList()
+        );
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/dto/HoldReservationData.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/dto/HoldReservationData.java
@@ -1,0 +1,19 @@
+package com.oneul_tanda.reservation_service.reservation.application.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record HoldReservationData(
+        int seatCount,
+        List<PassengerDto> passengers
+) {
+
+    public static HoldReservationData of(int seatCount, List<PassengerDto> passengers) {
+        return HoldReservationData.builder()
+                .seatCount(seatCount)
+                .passengers(passengers)
+                .build();
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/dto/PassengerDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/dto/PassengerDto.java
@@ -1,0 +1,20 @@
+package com.oneul_tanda.reservation_service.reservation.application.dto;
+
+import com.oneul_tanda.reservation_service.passenger.domain.entity.Gender;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDtoV2;
+
+public record PassengerDto(
+        String name,
+        String birth,
+        Gender gender,
+        String passportNumber
+) {
+    public static PassengerDto from(ConfirmReservationRequestDtoV2.ConfirmPassengerDtoV2 dto) {
+        return new PassengerDto(
+                dto.name(),
+                dto.birth(),
+                dto.gender(),
+                dto.passportNumber()
+        );
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/exception/ReservationErrorCode.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/exception/ReservationErrorCode.java
@@ -12,6 +12,7 @@ public enum ReservationErrorCode implements ErrorCode {
 
   // 예약 조회/접근 관련
   RESERVATION_NOT_FOUND("예약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  PASSENGERS_NOT_FOUND("탑승객 정보가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
   TICKET_NOT_FOUND("티켓을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   RESERVATION_ACCESS_UNAUTHORIZED("해당 예약에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
@@ -32,7 +33,12 @@ public enum ReservationErrorCode implements ErrorCode {
   FLIGHT_SEAT_RESTORE_FAILED("항공편 좌석 복원이 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
   PAYMENT_NOT_ALLOWED("결제 가능한 예약 상태가 아닙니다.", HttpStatus.BAD_REQUEST),
-  PAYMENT_FAILED("결제 요청에 실패하였습니다.", HttpStatus.BAD_GATEWAY);
+  PAYMENT_FAILED("결제 요청에 실패하였습니다.", HttpStatus.BAD_GATEWAY),
+
+  HOLD_RESERVATION_EXPIRED("임시 예약이 만료되었습니다. 다시 예약을 시도해주세요.", HttpStatus.BAD_REQUEST),
+  REDIS_SAVE_FAILED("Redis 저장에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  REDIS_LOAD_FAILED("Redis 데이터 읽기에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
 
 
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
@@ -28,5 +28,7 @@ public interface ReservationService {
 
     ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand command);
 
+    ConfirmReservationResponseDto confirmReservationV2(ConfirmReservationCommandV2 command);
+
     CancelReservationResponseDto cancelReservation(UUID reservationId);
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
@@ -1,6 +1,7 @@
 package com.oneul_tanda.reservation_service.reservation.application.service;
 
 import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
@@ -16,6 +17,8 @@ import java.util.UUID;
 public interface ReservationService {
 
     CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command);
+
+    void createHoldReservationV2(CreateHoldReservationCommand command);
 
     CreateReservationResponseDto createReservation(CreateReservationCommand command);
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneul_tanda.reservation_service.common.exception.CustomException;
 import com.oneul_tanda.reservation_service.passenger.domain.entity.Passenger;
 import com.oneul_tanda.reservation_service.reservation.application.dto.HoldReservationData;
+import com.oneul_tanda.reservation_service.reservation.application.dto.PassengerDto;
 import com.oneul_tanda.reservation_service.reservation.application.client.FlightClient;
 import com.oneul_tanda.reservation_service.reservation.application.client.PaymentClient;
 import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.CreatePaymentInfo;
 import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.exception.ReservationErrorCode;
@@ -160,7 +162,7 @@ public class ReservationServiceImpl implements ReservationService {
 
 
     /**
-     * 예약 확정 (1.탑승객 정보 입력 + 2.결제 -> 예약 확정)
+     * 예약 확정 V1 (1.탑승객 정보 입력 + 2.결제 -> 예약 확정)
      */
     @Override
     public ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand command) {
@@ -190,6 +192,79 @@ public class ReservationServiceImpl implements ReservationService {
 
         return ConfirmReservationResponseDto.from(reservation);
     }
+
+
+
+
+    /**
+     * 예약 확정 V2 (1.임시 예약 조회 및 검증 -> 2.탑승객 정보 입력 -> 3.예약 생성 -> 4.결제 -> 5.예약 확정)
+     */
+    @Override
+    public ConfirmReservationResponseDto confirmReservationV2(ConfirmReservationCommandV2 command) {
+
+        UUID flightId = command.flightId();
+        UUID userId = command.userId();
+        String key = "HoldReservation:" + flightId + ":" + userId;
+        List<PassengerDto> passengers;
+
+
+        // 1. Redis에서 임시 예약 조회 및 검증
+        HoldReservationData holdData = validateAndGetHoldReservation(key);
+        log.info("임시 예약 조회: {}", holdData);
+
+
+
+        // 2. 탑승객 정보 입력
+        if (command.passengers() != null && !command.passengers().isEmpty()) {
+            // 탑승객 정보가 요청에 있으면 (사용자가 처음 요청할 때)
+            passengers = command.passengers();
+            holdData = HoldReservationData.of(holdData.seatCount(), passengers);
+
+            try {
+                String updatedValue = objectMapper.writeValueAsString(holdData);
+                redisTemplate.opsForValue().set(key, updatedValue, Duration.ofMinutes(5));
+            } catch (JsonProcessingException e) {
+                log.error("Redis 탑승객 정보 업데이트 실패: {}", e.getMessage(), e);
+                throw new CustomException(ReservationErrorCode.REDIS_SAVE_FAILED);
+            }
+
+
+        } else {
+            // 탑승객 정보가 요청에 없으면 (결제 실패 후, 재시도할 때 -> Redis에 있는 탑승객 정보 사용)
+            if (holdData.passengers() == null || holdData.passengers().isEmpty()) {
+                throw new CustomException(ReservationErrorCode.PASSENGERS_NOT_FOUND);
+            }
+            passengers = holdData.passengers();
+        }
+
+
+
+        // 3. 예약 생성
+        GetFlightInfo flightInfo = flightClient.getFlight(flightId);
+        List<Ticket> ticketList = createTicketsFromHoldData(userId, flightInfo, passengers);
+        Reservation reservation = Reservation.createReservation(userId, ticketList);
+
+
+
+        // 4. 결제 요청
+        CreatePaymentInfo paymentInfo = requestPayment(reservation);
+        if (paymentInfo == null || !"PAID".equalsIgnoreCase(paymentInfo.status())) {
+            throw new CustomException(ReservationErrorCode.PAYMENT_FAILED);
+        }
+
+
+
+        // 5. 결제 성공 -> 예약 확정
+        reservation.confirmReservation();
+        reservationRepository.save(reservation);
+
+        // Redis 키 삭제
+        redisTemplate.delete(key);
+
+        return ConfirmReservationResponseDto.from(reservation);
+    }
+
+
 
 
 
@@ -250,6 +325,35 @@ public class ReservationServiceImpl implements ReservationService {
         }
 
         return ticketList;
+    }
+
+    // userId, flightInfo, Redis passengers 기반 티켓 리스트 생성
+    private List<Ticket> createTicketsFromHoldData(UUID userId, GetFlightInfo flightInfo, List<PassengerDto> passengers) {
+
+        List<Ticket> tickets = new ArrayList<>();
+
+        for (PassengerDto p : passengers) {
+            Passenger passenger = Passenger.createPassenger(
+                    userId,
+                    p.name(),
+                    p.birth(),
+                    p.gender(),
+                    p.passportNumber()
+            );
+
+            Ticket ticket = Ticket.createTicket(
+                    passenger,
+                    flightInfo.id(),
+                    userId,
+                    SeatClass.ECONOMY,
+                    flightInfo.price(),
+                    flightInfo.departureDate(),
+                    flightInfo.arrivalDate()
+            );
+
+            tickets.add(ticket);
+        }
+        return tickets;
     }
 
 
@@ -373,4 +477,23 @@ public class ReservationServiceImpl implements ReservationService {
             throw CustomException.from(ReservationErrorCode.RESERVATION_DUPLICATE);
         }
     }
+
+
+    // Redis에서 임시 예약 조회 및 검증
+    private HoldReservationData validateAndGetHoldReservation(String key) {
+
+        String value = redisTemplate.opsForValue().get(key);
+        if (value == null) {
+            throw new CustomException(ReservationErrorCode.HOLD_RESERVATION_EXPIRED);
+        }
+
+        try {
+            return objectMapper.readValue(value, HoldReservationData.class);
+        } catch (JsonProcessingException e) {
+            log.error("Redis 데이터 역직렬화 실패: {}", e.getMessage(), e);
+            throw new CustomException(ReservationErrorCode.REDIS_LOAD_FAILED);
+        }
+    }
+
+
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
@@ -1,7 +1,10 @@
 package com.oneul_tanda.reservation_service.reservation.application.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneul_tanda.reservation_service.common.exception.CustomException;
 import com.oneul_tanda.reservation_service.passenger.domain.entity.Passenger;
+import com.oneul_tanda.reservation_service.reservation.application.dto.HoldReservationData;
 import com.oneul_tanda.reservation_service.reservation.application.client.FlightClient;
 import com.oneul_tanda.reservation_service.reservation.application.client.PaymentClient;
 import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.CreatePaymentInfo;
@@ -23,9 +26,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -39,6 +44,8 @@ public class ReservationServiceImpl implements ReservationService {
     private final ReservationRepository reservationRepository;
     private final FlightClient flightClient;
     private final PaymentClient paymentClient;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
 
 
     /**
@@ -68,7 +75,7 @@ public class ReservationServiceImpl implements ReservationService {
 
 
     /**
-     * 예약 임시 생성
+     * 예약 임시 생성 V1
      */
     @Override
     public CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command) {
@@ -86,6 +93,41 @@ public class ReservationServiceImpl implements ReservationService {
         Reservation reservation = Reservation.createHoldReservation(command.userId(), ticketList);
 
         return CreateHoldReservationResponseDto.from(reservationRepository.save(reservation));
+    }
+
+
+
+    /**
+     * 예약 임시 생성 V2
+     */
+    @Override
+    public void createHoldReservationV2(CreateHoldReservationCommand command) {
+
+        UUID flightId = command.flightId();
+        UUID userId = command.userId();
+        int seatCount = command.seatCount();
+
+        String key = "HoldReservation:" + flightId + ":" + userId;
+
+        // 중복 임시 예약 생성 검증
+        validateDuplicateHoldReservation(key);
+
+        // 임시 예약 데이터 생성
+        HoldReservationData holdData = HoldReservationData.of(seatCount, new ArrayList<>());
+
+        // 임시 예약 데이터 Redis에 저장
+        try {
+            String value = objectMapper.writeValueAsString(holdData);
+            redisTemplate.opsForValue().set(key, value, Duration.ofMinutes(5));
+            log.info("임시 예약 생성 완료: {}", key);
+
+        } catch (JsonProcessingException e) {
+            log.error("임시 예약 저장 실패: {}", e.getMessage(), e);
+            // Todo 좌석 복구 or 알림 시스템에 예약 임시 생성 실패 전송
+            throw new CustomException(ReservationErrorCode.REDIS_SAVE_FAILED);
+        }
+
+        // Todo 예약 임시 생성 완료 이벤트 발행 or 알림 시스템에 예약 임시 생성 완료 전송
     }
 
 
@@ -294,6 +336,11 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
 
+
+
+
+
+    // === 검증 메서드 === //
     // 예약 내에서 특정 티켓 조회 및 존재 여부 검증
     private Ticket validateAndGetTicket(Reservation reservation, ConfirmReservationCommand.ConfirmTicketCommand ticketCommand) {
         return reservation.getTicketList().stream()
@@ -320,4 +367,10 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
 
+    // 중복 임시 예약 생성 검증
+    private void validateDuplicateHoldReservation(String key) {
+        if (redisTemplate.hasKey(key)) {
+            throw CustomException.from(ReservationErrorCode.RESERVATION_DUPLICATE);
+        }
+    }
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
@@ -120,7 +120,7 @@ public class ReservationServiceImpl implements ReservationService {
         // 임시 예약 데이터 Redis에 저장
         try {
             String value = objectMapper.writeValueAsString(holdData);
-            redisTemplate.opsForValue().set(key, value, Duration.ofMinutes(5));
+            redisTemplate.opsForValue().set(key, value, Duration.ofMinutes(2));
             log.info("임시 예약 생성 완료: {}", key);
 
         } catch (JsonProcessingException e) {

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/domain/entity/Reservation.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/domain/entity/Reservation.java
@@ -58,6 +58,11 @@ public class Reservation extends BaseTimeEntity {
             reservation.addTicket(ticket);
         }
 
+        // 총 가격 계산
+        reservation.calculateTotalPrice();
+
+        reservation.registerCreatedBy(userId);
+
         return reservation;
     }
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/client/FlightFeignClient.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/client/FlightFeignClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
-@FeignClient(name = "flight-service", url = "${flight-service.url}")
+@FeignClient(name = "flight-service")
 public interface FlightFeignClient {
 
     /**

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/client/PaymentFeignClient.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/client/PaymentFeignClient.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 
-@FeignClient(name = "payment-service", url = "${payment-service.url}")
+@FeignClient(name = "payment-service")
 public interface PaymentFeignClient {
 
     /**

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/client/dto/response/PaymentResponseDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/client/dto/response/PaymentResponseDto.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class PaymentResponseDto {
     private UUID reservationId;
-    private UUID paymentId;
+    private String paymentId;
     private BigDecimal totalPrice;
     private String status;
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/configuration/ReservationRedisConfig.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/configuration/ReservationRedisConfig.java
@@ -1,0 +1,32 @@
+package com.oneul_tanda.reservation_service.reservation.infrastructure.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+public class ReservationRedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.string());
+        return template;
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/ReservationHeldEventConsumer.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/ReservationHeldEventConsumer.java
@@ -35,7 +35,7 @@ public class ReservationHeldEventConsumer {
             );
 
             // 예약 임시 생성(사용자가 추후 예약정보 입력하여 예약 완료)
-            reservationService.createHoldReservation(command);
+            reservationService.createHoldReservationV2(command);
 
         } catch (FeignException e) {
             log.error("항공편 조회 실패 - flightId={}, error={}", event.data().flightId(), e.getMessage());

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
@@ -1,10 +1,12 @@
 package com.oneul_tanda.reservation_service.reservation.presentation;
 
 import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.service.ReservationService;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.create.CreateReservationRequestDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDtoV2;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
@@ -46,7 +48,7 @@ public class ReservationController {
 
 
     /**
-     * 에약 확정 (예약 수정)
+     * 에약 확정 V1 (RDB 기반)
      */
     @PutMapping("/{reservationId}/confirm")
     public ResponseEntity<ConfirmReservationResponseDto> confirmReservation(
@@ -54,6 +56,18 @@ public class ReservationController {
             @PathVariable UUID reservationId,
             @RequestBody @Valid ConfirmReservationRequestDto requestDto) {
         return ResponseEntity.ok(reservationService.confirmReservation(ConfirmReservationCommand.of(userId, reservationId, requestDto)));
+    }
+
+
+
+    /**
+     * 예약 확정 v2 (Redis 기반)
+     */
+    @PutMapping("/confirm")
+    public ResponseEntity<ConfirmReservationResponseDto> confirmReservationV2(
+            @RequestHeader("X-User-ID") UUID userId,
+            @RequestBody @Valid ConfirmReservationRequestDtoV2 requestDto) {
+        return ResponseEntity.ok(reservationService.confirmReservationV2(ConfirmReservationCommandV2.of(userId, requestDto)));
     }
 
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/request/update/ConfirmReservationRequestDtoV2.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/request/update/ConfirmReservationRequestDtoV2.java
@@ -1,0 +1,34 @@
+package com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update;
+
+import com.oneul_tanda.reservation_service.passenger.domain.entity.Gender;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ConfirmReservationRequestDtoV2(
+
+        @NotNull(message = "항공편 ID는 필수입니다.")
+        UUID flightId,
+
+        @Valid List<ConfirmPassengerDtoV2> passengers
+) {
+
+    public record ConfirmPassengerDtoV2(
+
+            String name,
+
+            @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "생년월일은 yyyy-MM-dd 형식이어야 합니다.")
+            String birth,
+
+            Gender gender,
+
+            @Size(min = 6, max = 10, message = "여권 번호는 6자 이상 10자 이하로 입력하세요.")
+            @Pattern(regexp = "[A-Z0-9]+", message = "여권 번호는 대문자와 숫자만 입력 가능합니다.")
+            String passportNumber
+    ) {}
+}
+

--- a/reservation-service/src/main/resources/application.yml
+++ b/reservation-service/src/main/resources/application.yml
@@ -21,6 +21,18 @@ spring:
         default_schema: reservation_db
         dialect: org.hibernate.dialect.MySQL8Dialect
 
+  data:
+    redis:
+      host: redis
+      port: 6379
+      timeout: 5000ms
+      lettuce:
+        pool:
+          max-active: 100
+          max-idle: 50
+          min-idle: 10
+          max-wait: 1000ms
+
 
   kafka:
     bootstrap-servers: kafka:29092

--- a/reservation-service/src/main/resources/application.yml
+++ b/reservation-service/src/main/resources/application.yml
@@ -4,8 +4,8 @@ spring:
 
   datasource:
     url: jdbc:mysql://reservation-db:3306/reservation_db
-    username: ${"RESERVATION_DB_ID"}
-    password: ${"RESERVATION_DB_PASSWORD"}
+    username: ${RESERVATION_DB_ID}
+    password: ${RESERVATION_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -4,8 +4,8 @@ spring:
 
   datasource:
     url: jdbc:mysql://oneultanda-user-db:3306/user_db
-    username: ${"USER_DB_ID"}
-    password: ${"USER_DB_PASSWORD"}
+    username: ${USER_DB_ID}
+    password: ${USER_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## 💡 이슈
resolve {#99}

## 🤩 개요
- [예약 확정 기능 리팩터링]
- Redis 기반 예약 확정 플로우 구현
- 예약 확정 성공 플로우: 1.임시 예약 조회 및 검증 -> 2.탑승객 정보 입력 -> 3.예약 생성 -> 4.결제 성공 -> 5.예약 확정
- 예약 확정 실패 플로우: 1.임시 예약 조회 및 검증 -> 2.탑승객 정보 입력 -> 3.예약 생성 -> 4.결제 실패 -> Redis에 탑승객 정보 유지한 체 예외 발생
- 다음 결제 재시도 요청에서 Redis에 존재하는 탑승객 정보 재사용

## 🧑‍💻 작업 사항
작업한 내용을 적어주세요.

## 📖 참고 사항
- 현재 예약 확정 기능에서 결제 재시도 부분을 고려하여 위해 일단은 dto의 탑승객 정보 유무에따라 사용자가 첫요청인지 결제 재시도 요청인지 판단하고 있지만, 이렇게 되었을 때 사용자가 모르고 탑승객 정보를 빼먹었을 때의 문제점 등이 발생합니다. 추후에 리펙터링을 통해 이러한 부분을 수정하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Redis 기반 임시 예약 및 예약 확정(V2) API가 추가되었습니다. 이제 임시 예약 데이터가 Redis에 저장되며, 새로운 예약 확정 엔드포인트(예약 확정 V2)가 제공됩니다.
  - 예약 확정 V2는 결제 재시도 시 승객 정보 없이도 요청할 수 있습니다.
  - 예약 확정 요청 및 승객 정보에 대한 새로운 데이터 구조와 유효성 검사가 도입되었습니다.

- **버그 수정**
  - MySQL, PostgreSQL 환경 변수 및 컨테이너 네임이 공식 이미지에 맞게 수정되어 서비스 초기화 및 인증이 정상 동작합니다.
  - 환경 변수 참조에서 불필요한 따옴표가 제거되어 Spring 설정이 올바르게 적용됩니다.

- **개선사항**
  - Kafka 기반 임시 예약 및 예약 확정 흐름이 문서 및 테스트 시나리오에 명확히 반영되었습니다.
  - 예약 관련 오류 코드가 확장되어, 승객 정보 누락, 임시 예약 만료, Redis 저장/조회 실패 등 다양한 오류 상황을 안내합니다.

- **설정**
  - Redis 연결 설정이 추가되어, 임시 예약 데이터의 효율적 관리를 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->