### PR TITLE
Feat/#107 payment service data log

### DIFF
--- a/payment-service/src/main/java/com/sparta/paymentservice/application/dto/PaymentResponseDto.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/application/dto/PaymentResponseDto.java
@@ -23,7 +23,7 @@ public class PaymentResponseDto {
     public static PaymentResponseDto toDto(Payment payment) {
         return PaymentResponseDto.builder()
                 .impUid(payment.getImpUid())
-                .reservationId(payment.getMerchantUid())
+                .reservationId(UUID.fromString(payment.getMerchantUid()))
                 .totalPrice(payment.getAmount())
                 .status(payment.getStatus())
                 .build();

--- a/payment-service/src/main/java/com/sparta/paymentservice/application/service/KcpPaymentService.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/application/service/KcpPaymentService.java
@@ -53,6 +53,8 @@ public class KcpPaymentService implements PaymentService {
             Payment payment = response.getResponse();
             // 결제 기록 저장
             Payments payments = Payments.create(reservationId, totalPrice, payment.getStatus());
+            payments.setCreatedAt(payment.getPaidAt());
+
             paymentRepository.save(payments);
 
             return PaymentResponseDto.toDto(payment);
@@ -82,6 +84,7 @@ public class KcpPaymentService implements PaymentService {
             Payment payment = response.getResponse();
 
             payments.updateStatus(payment.getStatus());
+            payments.setCancelledAt(payment.getCancelledAt());
 
             return PaymentResponseDto.toDto(payment);
         }  catch (IamportResponseException e) {

--- a/payment-service/src/main/java/com/sparta/paymentservice/domain/entity/Payments.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/domain/entity/Payments.java
@@ -35,7 +35,6 @@ public class Payments {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(nullable = false)
     private LocalDateTime cancelledAt;
 
     public static Payments create(UUID reservationId, BigDecimal totalPrice, String status) {

--- a/payment-service/src/main/java/com/sparta/paymentservice/domain/entity/Payments.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/domain/entity/Payments.java
@@ -55,8 +55,8 @@ public class Payments {
                 .toLocalDateTime();
     }
 
-    public void setCancelledAt(Date cancelAt) {
-        this.cancelledAt = cancelAt.toInstant()
+    public void setCancelledAt(Date cancelledAt) {
+        this.cancelledAt = cancelledAt.toInstant()
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
     }

--- a/payment-service/src/main/java/com/sparta/paymentservice/domain/entity/Payments.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/domain/entity/Payments.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.UUID;
 
 @Entity
@@ -29,6 +32,12 @@ public class Payments {
     @Column(nullable = false)
     private String status;
 
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime cancelledAt;
+
     public static Payments create(UUID reservationId, BigDecimal totalPrice, String status) {
         return Payments.builder()
                 .reservationId(reservationId)
@@ -39,5 +48,17 @@ public class Payments {
 
     public void updateStatus(String status) {
         this.status = status;
+    }
+
+    public void setCreatedAt(Date paidAt) {
+        this.createdAt = paidAt.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+    }
+
+    public void setCancelledAt(Date cancelAt) {
+        this.cancelledAt = cancelAt.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
     }
 }

--- a/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
@@ -122,7 +122,7 @@ public class QueueService {
 //                redisTemplate.opsForValue().set("seat:" + flightId, String.valueOf(remainingSeats));
                 // 실제 항공편 서비스 좌석 차감
                 flightClient.decreaseSeats(flightId, seatCount);
-                log.info("대기열 선점에 성공 했습니다. 남은 좌석 수: {}", remainingSeats);
+                log.info("대기열 선점에 성공 했습니다. 남은 좌석 수: {}", remainingSeats - seatCount);
                 rankOps.remove(key, reserveInfo);
                 producerService.sendReserveSuccess(flightId, userId, seatCount, EventStatusEnum.SUCCESS);
                 return QueueResponseDto.of(EventStatusEnum.SUCCESS, "대기열 선점에 성공했습니다.");

--- a/queue-service/src/main/java/com/sparta/queueservice/web/QueueController.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/web/QueueController.java
@@ -22,9 +22,7 @@ public class QueueController {
                                      @RequestHeader("X-User-ID") UUID userId) {
 
         QueueResponseDto response = queueService.tryReserve(request, userId);
-        HttpStatus status = response.getStatus() == EventStatusEnum.SUCCESS
-                ? HttpStatus.NO_CONTENT
-                : HttpStatus.CONFLICT;
-        return new ResponseEntity<>(response, status);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }


### PR DESCRIPTION
## 💡 이슈
resolve #107 

## 🤩 개요
결제 기록의 생성 시간과 취소 시간 기록

## 🧑‍💻 작업 사항
iamport api에서 제공하는 paidAt 과 cancelledAt 을 활용하였습니다. Date 타입으로 반환하고 있기 때문에 entity에서 localdatetime 타입으로 변환하여 저장 하고 있습니다.
그 외에는 reservaitonId를 response에 String으로 반환하고 있어서 UUID로 변경을 하고,
대기열 서비스에서  jmeter 테스트시 대기열 선점에 실패하면 전부 409 에러를 반환하기 때문에 오류로 인식해서 전부 200 ok 로 반환하도록 수정 했습니다. 
## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
