### PR TITLE
Feat/#106 reservation-service Kafka DLQ 설정

### DIFF
--- a/api-http-test/integration.http
+++ b/api-http-test/integration.http
@@ -52,46 +52,6 @@ Authorization: Bearer {{access_token}}
 ### 예약 서비스 Kafka Consumer: 예약 임시 생성
 
 
-### 예약 단일 조회
-GET http://localhost:19091/api/v1/reservations/9b7f421f-47b0-47f5-aa5c-8f489697a57d
-Content-Type: application/json
-Authorization: Bearer {{access_token}}
-
-
-## 예약 목록 조회
-### 예약 목록 조회 - Default
-GET http://localhost:19091/api/v1/reservations
-Content-Type: application/json
-Authorization: Bearer {{access_token}}
-
-
-### 예약 확정 V1(예약 수정)
-PUT http://localhost:19091/api/v1/reservations/df4aa5d2-2e7b-4728-a5b7-9cbbe1f7d35d/confirm
-Content-Type: application/json
-Authorization: Bearer {{access_token}}
-
-{
-  "tickets": [
-    {
-      "ticketId": "650662ec-d79d-4dfb-8aa6-e90a54f31f13",
-      "passenger": {
-        "name": "홍길동1",
-        "birth": "1990-01-01",
-        "gender": "MALE",
-        "passportNumber": "P12345678"
-      }
-    },
-    {
-      "ticketId": "b66c461c-ef14-4424-a5b6-d4c71d771842",
-      "passenger": {
-        "name": "홍길동",
-        "birth": "1995-06-10",
-        "gender": "FEMALE",
-        "passportNumber": "P87654321"
-      }
-    }
-  ]
-}
 
 
 ### 예약 확정 V2
@@ -126,3 +86,18 @@ Authorization: Bearer {{access_token}}
 {
   "flightId": "57944490-33fb-4bb1-9254-1eae30a1a25c"
 }
+
+
+
+
+### 예약 단일 조회
+GET http://localhost:19091/api/v1/reservations/9b7f421f-47b0-47f5-aa5c-8f489697a57d
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+
+## 예약 목록 조회
+### 예약 목록 조회 - Default
+GET http://localhost:19091/api/v1/reservations
+Content-Type: application/json
+Authorization: Bearer {{access_token}}

--- a/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
@@ -124,7 +124,7 @@ public class QueueService {
                 flightClient.decreaseSeats(flightId, seatCount);
                 log.info("대기열 선점에 성공 했습니다. 남은 좌석 수: {}", remainingSeats);
                 rankOps.remove(key, reserveInfo);
-                producerService.sendReserveSuccess(flightId, userId, seatCount, EventStatusEnum.SUCCESS);
+                producerService.sendReserveSuccess(flightId, userId, seatCount);
                 return QueueResponseDto.of(EventStatusEnum.SUCCESS, "대기열 선점에 성공했습니다.");
             } else {
                 log.info("남은 좌석이 없습니다. 남은 좌석 수: {}", remainingSeats);

--- a/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/ProducerService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/ProducerService.java
@@ -16,17 +16,10 @@ public class ProducerService {
     private final KafkaTemplate<String, ReservationHeldEvent> kafkaTemplate;
 
     // 대기열 선점 성공시 성공 메시지 전달
-    public void sendReserveSuccess(UUID flightId, UUID userId, int seatCount, EventStatusEnum status) {
+    public void sendReserveSuccess(UUID flightId, UUID userId, int seatCount) {
         ReservationHeldEvent event = ReservationHeldEvent
-                .createReservationEvent(flightId, userId, seatCount, status);
+                .createReservationEvent(flightId, userId, seatCount, "reservation-held");
 
         kafkaTemplate.send("reservation-held", flightId.toString(), event);
-    }
-    // 대기열 선점 실패시 실패 메세지 전달
-    public void sendReserveFailed(UUID flightId, UUID userId, int seatCount,  EventStatusEnum status) {
-        ReservationHeldEvent event = ReservationHeldEvent
-                .createReservationEvent(flightId, userId, seatCount, status);
-
-        kafkaTemplate.send("reservation-failed", flightId.toString(), event);
     }
 }

--- a/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/event/ReservationHeldEvent.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/event/ReservationHeldEvent.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class ReservationHeldEvent {
         private UUID eventId;
-        private EventStatusEnum status;
+        private String eventType;
         private LocalDateTime reservationTime;
         private Data data;
 
@@ -28,10 +28,10 @@ public class ReservationHeldEvent {
     public static ReservationHeldEvent createReservationEvent(UUID flightId,
                                                               UUID userId,
                                                               Integer seatCount,
-                                                              EventStatusEnum status) {
+                                                              String eventType) {
         return ReservationHeldEvent.builder()
                 .eventId(UUID.randomUUID())
-                .status(status)
+                .eventType(eventType)
                 .reservationTime(LocalDateTime.now())
                 .data(ReservationHeldEvent.Data.builder()
                         .flightId(flightId)

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/config/ReservationKafkaConfig.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/config/ReservationKafkaConfig.java
@@ -1,8 +1,13 @@
 package com.oneul_tanda.reservation_service.config;
 
 import com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event.ReservationHeldEvent;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +15,14 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,45 +31,98 @@ import java.util.Map;
 /**
  * Kafka 컨슈머 설정을 위한 Spring 설정 클래스
  */
+@Slf4j
 @EnableKafka
 @Configuration
 public class ReservationKafkaConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
+
+
     /**
-     * ReservationHeldEvent 타입의 Kafka ConsumerFactory 빈 정의
-     * - Kafka 컨슈머 인스턴스를 생성하는 팩토리
-     * - 메시지의 key는 String, value는 ReservationHeldEvent
-     * - JsonDeserializer를 통해 ReservationHeldEvent 역직렬화 처리
+     * Kafka에서 ReservationHeldEvent 메시지를 소비하기 위한 ConsumerFactory 빈 설정
+     *
+     * - Kafka 메시지의 key는 String, value는 ReservationHeldEvent 클래스.
+     * - 역직렬화 오류를 처리하기 위해 ErrorHandlingDeserializer를 래핑하여 사용.
+     * - 메시지 역직렬화를 위해 JsonDeserializer를 사용.
+     * - TRUSTED_PACKAGES 설정을 통해 역직렬화 허용 패키지를 명시.
+     * - KafkaListener에서 사용할 Kafka Consumer 인스턴스를 생성하는 팩토리 역할.
      */
     @Bean
     public ConsumerFactory<String, ReservationHeldEvent> reservationHeldConsumerFactory() {
 
-        JsonDeserializer<ReservationHeldEvent> jsonDeserializer = new JsonDeserializer<>(ReservationHeldEvent.class);
-        jsonDeserializer.addTrustedPackages("com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event");
-
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
 
-        return new DefaultKafkaConsumerFactory<>(
-                configProps,
-                new StringDeserializer(),
-                jsonDeserializer
-        );
+        configProps.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        configProps.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+
+        configProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE,
+                "com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event.ReservationHeldEvent");
+
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES,
+                "com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event");
+
+        return new DefaultKafkaConsumerFactory<>(configProps);
     }
 
 
+
+    //DLQ용 KafkaTemplate 설정
+    @Bean
+    public KafkaTemplate<String, byte[]> dlqKafkaTemplate() {
+
+        Map<String, Object> producerProps = new HashMap<>();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+
+        return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(producerProps));
+    }
+
+
+
     /**
-     * ReservationHeldEvent 타입의 Kafka 리스너 컨테이너 팩토리 빈 정의
-     * - @KafkaListener 메서드를 실행할 컨테이너를 생성
-     * - 내부적으로 reservationHeldConsumerFactory를 사용하여 컨슈머 생성
+     * KafkaListener에서 ReservationHeldEvent 메시지를 처리하기 위한 리스너 컨테이너 팩토리 설정
+     *
+     * - Kafka 메시지를 처리할 리스너 컨테이너를 생성하는 팩토리.
+     * - 내부적으로 reservationHeldConsumerFactory를 사용하여 Consumer 인스턴스를 생성.
+     * - 메시지 처리 중 예외가 발생하면 DLQ(Dead Letter Queue)로 전송되도록 에러 핸들러를 설정.
+     * - @KafkaListener 어노테이션이 붙은 메서드에서 이 팩토리를 통해 Kafka 메시지를 처리.
      */
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, ReservationHeldEvent> reservationHeldListenerFactory() {
+    public ConcurrentKafkaListenerContainerFactory<String, ReservationHeldEvent> reservationHeldListenerFactory(
+            KafkaTemplate<String, byte[]> dlqKafkaTemplate) {
+
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(dlqKafkaTemplate,
+                (record, ex) -> {
+                    log.warn("[DLQ] 실패 메시지 전송. key={}, cause={}", record.key(), ex.getMessage());
+                    return new TopicPartition("reservation-held-dlq", 0);
+                });
+
+
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3));
+
+        errorHandler.addRetryableExceptions(
+                RuntimeException.class,
+                DeserializationException.class
+        );
+
+        errorHandler.setRetryListeners((record, ex, deliveryAttempt) -> {
+            if (deliveryAttempt == 1) {
+                log.warn("[초기 처리 실패] key={}, value={}, cause={}", record.key(), record.value(), ex.getMessage());
+            } else {
+                log.warn("[재시도] {}번째 시도 실패 - key: {}, value: {}, exception type: {}, cause={}",
+                        deliveryAttempt - 1, record.key(), record.value(),
+                        ex.getClass().getSimpleName(), ex.getMessage());
+            }
+        });
+
         ConcurrentKafkaListenerContainerFactory<String, ReservationHeldEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setCommonErrorHandler(errorHandler);
         factory.setConsumerFactory(reservationHeldConsumerFactory());
         return factory;
     }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/ReservationHeldEventConsumer.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/ReservationHeldEventConsumer.java
@@ -26,24 +26,24 @@ public class ReservationHeldEventConsumer {
     public void consumeReservationHeldForReservation(ReservationHeldEvent event) {
 
         try{
-            var data = event.data();
+            ReservationHeldEvent.Data data = event.getData();
 
             CreateHoldReservationCommand command = CreateHoldReservationCommand.of(
-                    data.flightId(),
-                    data.userId(),
-                    data.seatCount()
+                    data.getFlightId(),
+                    data.getUserId(),
+                    data.getSeatCount()
             );
 
             // 예약 임시 생성(사용자가 추후 예약정보 입력하여 예약 완료)
             reservationService.createHoldReservationV2(command);
 
         } catch (FeignException e) {
-            log.error("항공편 조회 실패 - flightId={}, error={}", event.data().flightId(), e.getMessage());
-            // 좌석 복원 보상 이벤트 발행? (예: DLQ 또는 Kafka 재시도)
+            log.error("항공편 조회 실패 - flightId={}, error={}", event.getData().getFlightId(), e.getMessage());
+            throw e; // DLQ 또는 재시도 유도됨
 
         } catch (Exception e) {
             log.error("임시 예약 생성 실패: {}, {}", event, e.getMessage(), e);
-            // -> 여기서도 DLQ 보내거나 알림, 재시도 큐 등록 등 처리 가능
+            throw e; // DLQ 또는 재시도 유도됨
         }
 
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/event/ReservationHeldEvent.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/event/ReservationHeldEvent.java
@@ -1,20 +1,28 @@
 package com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.event;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record ReservationHeldEvent(
-        String eventId,                    // 대상: 이벤트 고유 ID or 이벤트 대상 ID
-        String eventType,                  // 행위: 이벤트 타입    (ex: 예약 선점)
-        LocalDateTime occurrenceDateTime,  // 시간: 행위 발생 시각  (ex: 선점이 일어난 시간)
-        Data data                          // 정보: 행위와 관련된 정보
-) {
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationHeldEvent {
+    private UUID eventId;                   // 대상: 이벤트 고유 ID or 이벤트 대상 ID
+    private String eventType;               // 행위: 이벤트 타입    (ex: 예약 선점)
+    private LocalDateTime reservationTime;  // 시간: 행위 발생 시각  (ex: 선점이 일어난 시간)
+    private Data data;                      // 정보: 행위와 관련된 정보
 
-    public record Data(
-            UUID flightId,
-            UUID userId,
-            int seatCount
-    ) {}
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Data {
+        private UUID flightId;
+        private UUID userId;
+        private Integer seatCount;
+    }
 }
 

--- a/reservation-service/src/main/resources/application.yml
+++ b/reservation-service/src/main/resources/application.yml
@@ -37,9 +37,13 @@ spring:
   kafka:
     bootstrap-servers: kafka:29092
     consumer:
+      group-id: reservation-service
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        allow.auto.create.topics: true
 
 
 ## actuator and prometheus setting


### PR DESCRIPTION
## 💡 이슈
resolve {#106}

## 🤩 개요
- Kafka 예약 컨슈머에서 발생하던 역직렬화 오류 및 무한 재시도 루프 문제를 해결하기 위한 DLQ(Dead Letter Queue) 설정 추가

## 🧑‍💻 작업 사항
- Deserializer 구성: 기존 단일 JsonDeserializer -> ErrorHandlingDeserializer로 래핑하여 예외 발생 시 감지 가능하게 구성
- DLQ용 KafkaTemplate 설정: 실패 메시지를 reservation-held-dlq 토픽으로 전송할 수 있도록 KafkaTemplate<String, byte[]> 구성
- DeadLetterPublishingRecoverer + DefaultErrorHandler로 DLQ 전송 처리
   - 역직렬화 실패 시 메시지를 reservation-held-dlq 토픽으로 전송
   - 재시도 간격: 1초, 최대 재시도 횟수: 3회

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Kafka consumer error handling with automatic retries and support for a dead letter queue (DLQ) for reservation events.
- **Refactor**
	- Updated reservation event structure for improved clarity and consistency.
	- Streamlined event status handling by replacing enums with a string event type.
- **Chores**
	- Improved Kafka configuration for better error resilience and topic management.
- **Bug Fixes**
	- Ensured exceptions during reservation event processing are correctly propagated for DLQ or retry handling.
- **Tests**
	- Updated integration test examples to focus on reservation retrieval endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->