### PR TITLE
Feat/#113 reservation-service 예약 삭제

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,18 +43,16 @@ services:
       - redis
 
   user-db:
-    image: mysql:8.0
+    image: postgres:16.3
     container_name: oneultanda-user-db
-    restart: always
     environment:
-      - MYSQL_ROOT_PASSWORD=${USER_DB_ROOT_PASSWORD}
-      - MYSQL_DATABASE=user_db
-      - MYSQL_USER=${USER_DB_ID}
-      - MYSQL_PASSWORD=${USER_DB_PASSWORD}
+      - POSTGRES_USER=${USER_DB_ID}
+      - POSTGRES_DB=user_db
+      - POSTGRES_PASSWORD=${USER_DB_PASSWORD}
     ports:
-      - "3309:3306"
+      - "5432:5432"
     volumes:
-      - user-mysql-data:/var/lib/mysql
+      - user-postgres-data:/var/lib/postgresql/data
 
   flight-service:
     build:
@@ -105,17 +103,16 @@ services:
       - eureka-server
 
   reservation-db:
-    image: mysql:8.0
+    image: postgres:16.3
     container_name: oneultanda-reservation-db
     environment:
-      - MYSQL_ROOT_PASSWORD=${RESERVATION_DB_ROOT_PASSWORD}
-      - MYSQL_DATABASE=reservation_db
-      - MYSQL_USER=${RESERVATION_DB_ID}
-      - MYSQL_PASSWORD=${RESERVATION_DB_PASSWORD}
+      - POSTGRES_USER=${RESERVATION_DB_ID}
+      - POSTGRES_DB=reservation_db
+      - POSTGRES_PASSWORD=${RESERVATION_DB_PASSWORD}
     ports:
-      - "3307:3306"
+      - "5434:5432"
     volumes:
-      - reservation-mysql-data:/var/lib/mysql
+      - reservation-postgres-data:/var/lib/postgresql/data
 
   queue-service:
     build:
@@ -156,19 +153,16 @@ services:
       - eureka-server
 
   payments-db:
-    image: mysql:8.0
-    container_name: oneultanda-payment-db
+    image: postgres:16.3
+    container_name: oneultanda-payments-db
     environment:
-      - MYSQL_ROOT_PASSWORD=${PAYMENT_DB_ROOT_PASSWORD}
-      - MYSQL_DATABASE=payments_db
-      - MYSQL_USER=${PAYMENT_DB_USERNAME}
-      - MYSQL_PASSWORD=${PAYMENT_DB_PASSWORD}
-      - IMPORT_API_KEY=${IMPORT_API_KEY}
-      - IMPORT_API_SECRET_KEY=${IMPORT_API_SECRET_KEY}
+      - POSTGRES_USER=${PAYMENT_DB_USERNAME}
+      - POSTGRES_DB=payments_db
+      - POSTGRES_PASSWORD=${PAYMENT_DB_PASSWORD}
     ports:
-      - "3308:3306"
+      - "5435:5432"
     volumes:
-      - payments-mysql-data:/var/lib/mysql
+      - payments-postgres-data:/var/lib/postgresql/data
 
   zookeeper:
     image: wurstmeister/zookeeper:latest
@@ -235,9 +229,9 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
 
 volumes:
-  user-mysql-data:
-  reservation-mysql-data:
+  user-postgres-data:
+  reservation-postgres-data:
   flight-postgres-data:
-  payments-mysql-data:
+  payments-postgres-data:
   prometheus_data:
   grafana-storage:

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
@@ -4,6 +4,7 @@ import com.oneul_tanda.reservation_service.reservation.application.command.Confi
 import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.DeleteReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
@@ -31,4 +32,6 @@ public interface ReservationService {
     ConfirmReservationResponseDto confirmReservationV2(ConfirmReservationCommandV2 command);
 
     CancelReservationResponseDto cancelReservation(UUID reservationId);
+
+    DeleteReservationResponseDto deleteReservation(UUID userId, UUID reservationId);
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
@@ -17,6 +17,7 @@ import com.oneul_tanda.reservation_service.reservation.application.exception.Res
 import com.oneul_tanda.reservation_service.reservation.domain.entity.Reservation;
 import com.oneul_tanda.reservation_service.reservation.domain.repository.ReservationRepository;
 import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.GetFlightInfo;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.DeleteReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
@@ -289,7 +290,24 @@ public class ReservationServiceImpl implements ReservationService {
 
 
 
-    
+
+    /**
+     * 예약 삭제
+     */
+    @Override
+    public DeleteReservationResponseDto deleteReservation(UUID userId, UUID reservationId) {
+        // 예약 조회
+        Reservation reservation = getReservationOrThrow(reservationId);
+        
+        // 예약 삭제
+        reservation.markDeleted(userId);
+        
+        return DeleteReservationResponseDto.of(reservation.getId());
+    }
+
+
+
+
     // 예약 조회
     private Reservation getReservationOrThrow(UUID reservationId) {
         return reservationRepository.findById(reservationId)

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
@@ -106,7 +106,7 @@ public class ReservationController {
      * 예약 삭제
      */
     @DeleteMapping("/{reservationId}")
-    public ResponseEntity<DeleteReservationResponseDto> DeleteReservation(
+    public ResponseEntity<DeleteReservationResponseDto> deleteReservation(
             @RequestHeader("X-User-Id") UUID userId,
             @PathVariable UUID reservationId
     ) {

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
@@ -4,6 +4,7 @@ import com.oneul_tanda.reservation_service.reservation.application.command.Confi
 import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.service.ReservationService;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.DeleteReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.create.CreateReservationRequestDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDtoV2;
@@ -97,5 +98,18 @@ public class ReservationController {
     @PutMapping("/{reservationId}/cancel")
     public ResponseEntity<CancelReservationResponseDto> cancelReservation(@PathVariable UUID reservationId) {
         return ResponseEntity.ok(reservationService.cancelReservation(reservationId));
+    }
+
+
+
+    /**
+     * 예약 삭제
+     */
+    @DeleteMapping("/{reservationId}")
+    public ResponseEntity<DeleteReservationResponseDto> DeleteReservation(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable UUID reservationId
+    ) {
+        return ResponseEntity.ok(reservationService.deleteReservation(userId, reservationId));
     }
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/DeleteReservationResponseDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/DeleteReservationResponseDto.java
@@ -1,0 +1,14 @@
+package com.oneul_tanda.reservation_service.reservation.presentation.dto;
+
+import java.util.UUID;
+
+public record DeleteReservationResponseDto(
+        UUID reservationId
+) {
+
+    public static DeleteReservationResponseDto of(UUID reservationId) {
+        return new DeleteReservationResponseDto(
+                reservationId
+        );
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/DeleteReservationResponseDto.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/dto/DeleteReservationResponseDto.java
@@ -1,5 +1,6 @@
 package com.oneul_tanda.reservation_service.reservation.presentation.dto;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public record DeleteReservationResponseDto(
@@ -8,7 +9,7 @@ public record DeleteReservationResponseDto(
 
     public static DeleteReservationResponseDto of(UUID reservationId) {
         return new DeleteReservationResponseDto(
-                reservationId
+                Objects.requireNonNull(reservationId)
         );
     }
 }

--- a/reservation-service/src/test/http/reservation-service.http
+++ b/reservation-service/src/test/http/reservation-service.http
@@ -151,3 +151,16 @@ Authorization: Bearer {{access_token}}
 PUT http://localhost:19095/api/v1/reservations/791f1aa3-f2b1-4d08-bbf7-cb236090e30d/cancel
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
+
+
+
+### 예약 삭제
+DELETE http://localhost:19091/api/v1/reservations/b9f9c07b-0b9a-4166-8ffe-5f0673ffe9f0
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+
+
+
+
+

--- a/reservation-service/src/test/http/reservation-service.http
+++ b/reservation-service/src/test/http/reservation-service.http
@@ -1,7 +1,21 @@
+### 로그인
+POST http://localhost:19091/api/v1/users/login
+Content-Type: application/json
+
+{
+  "username": "tester",
+  "password": "12345678a*"
+}
+> {%
+    client.global.set("access_token", response.headers.valueOf("Authorization"))
+%}
+
+
+
 ### 예약 생성 성공
 POST http://localhost:19095/api/v1/reservations
 Content-Type: application/json
-X-User-ID: 9b7f421f-47b0-47f5-aa5c-8f489697a57d
+Authorization: Bearer {{access_token}}
 
 {
   "flightId": "0e7d0581-2962-40ef-aa92-4105b46cca06",
@@ -27,7 +41,7 @@ X-User-ID: 9b7f421f-47b0-47f5-aa5c-8f489697a57d
 ### 예약 생성 실패 (Valid 테스트)
 POST http://localhost:19095/api/v1/reservations
 Content-Type: application/json
-X-User-ID: 9b7f421f-47b0-47f5-aa5c-8f489697a57d
+Authorization: Bearer {{access_token}}
 
 {
   "flightId": "49834e83-95e2-4a39-9d6a-36d7fe1d88ee",
@@ -52,24 +66,27 @@ X-User-ID: 9b7f421f-47b0-47f5-aa5c-8f489697a57d
 ### 예약 단일 조회
 GET http://localhost:19095/api/v1/reservations/9b7f421f-47b0-47f5-aa5c-8f489697a57d
 Content-Type: application/json
-
+Authorization: Bearer {{access_token}}
 
 
 ## 예약 목록 조회
 ### 예약 목록 조회 - Default
 GET http://localhost:19095/api/v1/reservations
 Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+
 
 ### 예약 목록 조회 - 1페이지, 5개씩 조회
 GET http://localhost:19095/api/v1/reservations?page=1&size=5
 Content-Type: application/json
-
+Authorization: Bearer {{access_token}}
 
 
 ### 예약 확정(예약 수정)
 PUT http://localhost:19095/api/v1/reservations/c8b4c5e1-4668-4055-bd2c-b0a6b2d18d1a/confirm
 Content-Type: application/json
-X-User-ID: 9b7f421f-47b0-47f5-aa5c-8f489697a57d
+Authorization: Bearer {{access_token}}
 
 {
   "tickets": [
@@ -95,8 +112,42 @@ X-User-ID: 9b7f421f-47b0-47f5-aa5c-8f489697a57d
 }
 
 
+### 예약 확정 V2
+PUT http://localhost:19091/api/v1/reservations/confirm
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "flightId": "57944490-33fb-4bb1-9254-1eae30a1a25c",
+  "passengers": [
+    {
+      "name": "홍길동1",
+      "birth": "1990-01-01",
+      "gender": "MALE",
+      "passportNumber": "P12345678"
+    },
+    {
+      "name": "홍길동",
+      "birth": "1995-06-10",
+      "gender": "FEMALE",
+      "passportNumber": "P87654321"
+    }
+  ]
+}
+
+
+### 예약 확정 V2, 결제 재시도
+PUT http://localhost:19091/api/v1/reservations/confirm
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "flightId": "57944490-33fb-4bb1-9254-1eae30a1a25c"
+}
+
+
 
 ### 예약 취소(예약 수정)
 PUT http://localhost:19095/api/v1/reservations/791f1aa3-f2b1-4d08-bbf7-cb236090e30d/cancel
 Content-Type: application/json
-X-User-ID: 9b7f421f-47b0-47f5-aa5c-8f489697a57d
+Authorization: Bearer {{access_token}}


### PR DESCRIPTION
## 💡 이슈
resolve {#113}

## 🤩 개요
- 예약 삭제 기능 추가
 
## 🧑‍💻 작업 사항
- 예약을 소프트 삭제되도록 기능 추가.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 예약 삭제 API 엔드포인트가 추가되어 사용자가 예약을 삭제할 수 있습니다.

- **테스트**
  - 예약 삭제 및 예약 확정 V2 관련 HTTP 테스트 케이스가 추가되었습니다.
  - 인증 방식이 X-User-ID 헤더에서 Bearer 토큰 방식으로 통일되었습니다.

- **기타**
  - 데이터베이스 서비스가 MySQL에서 PostgreSQL로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->