### PR TITLE
Feat/#115 flight-service kafka 적용을 통한 좌석 복구 비동기 처리 increaseSeatsV2 추가

### DIFF
--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -61,6 +61,7 @@ services:
     depends_on:
       - flight-db
       - redis
+      - kafka
       - eureka-server
 
   flight-db:
@@ -147,7 +148,6 @@ services:
       - "5435:5432"
     volumes:
       - payments-postgres-data:/var/lib/postgresql/data
-
 
   zookeeper:
     image: wurstmeister/zookeeper:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
     depends_on:
       - flight-db
       - redis
+      - kafka
       - eureka-server
 
   flight-db:

--- a/flight-service/build.gradle
+++ b/flight-service/build.gradle
@@ -62,6 +62,10 @@ dependencies {
 	// postgresql
 	runtimeOnly 'org.postgresql:postgresql'
 
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 	// web
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/dtos/event/ReservationCanceledEvent.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/dtos/event/ReservationCanceledEvent.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.application.event;
+package com.oneul_tanda.flight_service.application.dtos.event;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/event/FlightEventKafkaListener.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/event/FlightEventKafkaListener.java
@@ -1,5 +1,7 @@
 package com.oneul_tanda.flight_service.application.event;
 
+import com.oneul_tanda.flight_service.application.dtos.event.ReservationCanceledEvent;
+
 public interface FlightEventKafkaListener {
 
     void consumePaymentCanceledFromPayment(ReservationCanceledEvent event);

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/event/FlightEventKafkaListener.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/event/FlightEventKafkaListener.java
@@ -1,0 +1,6 @@
+package com.oneul_tanda.flight_service.application.event;
+
+public interface FlightEventKafkaListener {
+
+    void consumePaymentCanceledFromPayment(ReservationCanceledEvent event);
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/event/FlightEventKafkaProducer.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/event/FlightEventKafkaProducer.java
@@ -1,0 +1,8 @@
+package com.oneul_tanda.flight_service.application.event;
+
+import java.util.UUID;
+
+public interface FlightEventKafkaProducer {
+
+    void sendFlightSeatRecovered(UUID reservationId, UUID flightId, Integer seatCount);
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/event/ReservationCanceledEvent.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/event/ReservationCanceledEvent.java
@@ -1,0 +1,44 @@
+package com.oneul_tanda.flight_service.application.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationCanceledEvent {
+    private UUID eventId;                   // 대상: 이벤트 고유 ID or 이벤트 대상 ID
+    private String eventType;               // 행위: 이벤트 타입    (ex: 예약 선점)
+    private LocalDateTime reservationCanceledTime;  // 시간: 행위 발생 시각  (ex: 선점이 일어난 시간)
+    private Data data;                      // 정보: 행위와 관련된 정보
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Data {
+        private UUID flightId;
+        private Integer seatCount;
+    }
+
+    public static ReservationCanceledEvent of(UUID reservationId,
+                                              UUID flightId,
+                                              Integer seatCount,
+                                              String eventType
+    ) {
+        return ReservationCanceledEvent.builder()
+                .eventId(reservationId)
+                .eventType(eventType)
+                .reservationCanceledTime(LocalDateTime.now())
+                .data(ReservationCanceledEvent.Data.builder()
+                        .flightId(flightId)
+                        .seatCount(seatCount)
+                        .build())
+                .build();
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightService.java
@@ -2,6 +2,7 @@ package com.oneul_tanda.flight_service.application.service.flight;
 
 import com.oneul_tanda.flight_service.application.dtos.flight.CreateFlightCommand;
 import com.oneul_tanda.flight_service.application.dtos.flight.UpdateFlightCommand;
+import com.oneul_tanda.flight_service.application.event.FlightEventKafkaProducer;
 import com.oneul_tanda.flight_service.domain.entity.AirlineEntity;
 import com.oneul_tanda.flight_service.domain.entity.AirportEntity;
 import com.oneul_tanda.flight_service.domain.entity.FlightEntity;
@@ -39,6 +40,7 @@ public class FlightService {
     private final FlightRepositoryCustom flightRepositoryCustom;
     private final AirlineRepository airlineRepository;
     private final AirportRepository airportRepository;
+    private final FlightEventKafkaProducer flightEventKafkaProducer;
 
     @Cacheable(value = "flights", key = "#flightId")
     public FlightDetailResponse getFlight(UUID flightId) {
@@ -148,6 +150,18 @@ public class FlightService {
         FlightEntity flight = getFlightById(flightId);
 
         flight.increaseSeatCount(requiredSeats);
+    }
+
+    // 예약 취소(결제 취소)시 좌석 복구 비동기 처리
+    @Transactional
+    @CacheEvict(value = "flights", key = "#flightId") // 캐시 무효화
+    public void increaseSeatsV2(UUID reservationId, UUID flightId, Integer requiredSeats) {
+        FlightEntity flight = getFlightById(flightId);
+
+        flight.increaseSeatCount(requiredSeats);
+
+        // 좌석 복구 후, 예약 서비스로 이벤트 발행
+        flightEventKafkaProducer.sendFlightSeatRecovered(reservationId, flightId, requiredSeats);
     }
 
     private AirportEntity getArrivalAirportForUpdateFlight(UpdateFlightCommand flightCommand) {

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/entity/FlightEntity.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/entity/FlightEntity.java
@@ -1,6 +1,7 @@
 package com.oneul_tanda.flight_service.domain.entity;
 
 import com.oneul_tanda.flight_service.common.BaseTimeEntity;
+import com.oneul_tanda.flight_service.domain.exception.common.InvalidRequestException;
 import com.vladmihalcea.hibernate.type.interval.PostgreSQLIntervalType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -107,17 +108,17 @@ public class FlightEntity extends BaseTimeEntity {
 
     public void decreaseSeatCount(Integer requiredSeats) {
         if (requiredSeats == null || requiredSeats <= 0) {
-            throw new IllegalArgumentException("Required seats must be positive");
+            throw new InvalidRequestException();
         }
         if (this.remainingSeats < requiredSeats) {
-            throw new IllegalStateException("Not enough seats");
+            throw new InvalidRequestException();
         }
         this.remainingSeats -= requiredSeats;
     }
 
     public void increaseSeatCount(Integer requiredSeats) {
         if (requiredSeats == null || requiredSeats <= 0) {
-            throw new IllegalArgumentException("Seats to add must be positive");
+            throw new InvalidRequestException();
         }
         this.remainingSeats += requiredSeats;
     }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/KafkaConsumerConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,59 @@
+package com.oneul_tanda.flight_service.infrastructure.config;
+
+import com.oneul_tanda.flight_service.application.event.ReservationCanceledEvent;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    // 예약 취소(결제 취소) ConsumerFactory
+    @Bean
+    public ConsumerFactory<String, ReservationCanceledEvent> paymentCanceledConsumerFactory() {
+        JsonDeserializer<ReservationCanceledEvent> valueDeserializer = new JsonDeserializer<>(
+                ReservationCanceledEvent.class);
+        valueDeserializer.setUseTypeMapperForKey(false);
+        valueDeserializer.setRemoveTypeHeaders(true);
+        valueDeserializer.addTrustedPackages("com.oneul_tanda.flight_service.application.event");
+
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+
+        configProps.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        configProps.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(), valueDeserializer);
+    }
+
+    // 예약 취소(결제 취소) ContainerFactory
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ReservationCanceledEvent> paymentCanceledListenerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ReservationCanceledEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(paymentCanceledConsumerFactory());
+        // 에러 핸들러 설정 (기본적으로 재시도 0, DLQ 구성 가능)
+        factory.setCommonErrorHandler(new DefaultErrorHandler());
+        return factory;
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/KafkaConsumerConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/KafkaConsumerConfig.java
@@ -1,6 +1,6 @@
 package com.oneul_tanda.flight_service.infrastructure.config;
 
-import com.oneul_tanda.flight_service.application.event.ReservationCanceledEvent;
+import com.oneul_tanda.flight_service.application.dtos.event.ReservationCanceledEvent;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/KafkaProducerConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/KafkaProducerConfig.java
@@ -1,6 +1,6 @@
 package com.oneul_tanda.flight_service.infrastructure.config;
 
-import com.oneul_tanda.flight_service.application.event.ReservationCanceledEvent;
+import com.oneul_tanda.flight_service.application.dtos.event.ReservationCanceledEvent;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/KafkaProducerConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,38 @@
+package com.oneul_tanda.flight_service.infrastructure.config;
+
+import com.oneul_tanda.flight_service.application.event.ReservationCanceledEvent;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, ReservationCanceledEvent> flightSeatRecoveredProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        JsonSerializer<ReservationCanceledEvent> jsonSerializer = new JsonSerializer<>();
+        jsonSerializer.setAddTypeInfo(false);
+
+        return new DefaultKafkaProducerFactory<>(configProps, new StringSerializer(), jsonSerializer);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ReservationCanceledEvent> flightSeatRecoveredKafkaTemplate() {
+        return new KafkaTemplate<>(flightSeatRecoveredProducerFactory());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/event/FlightEventKafkaListenerImpl.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/event/FlightEventKafkaListenerImpl.java
@@ -1,7 +1,7 @@
 package com.oneul_tanda.flight_service.infrastructure.event;
 
 import com.oneul_tanda.flight_service.application.event.FlightEventKafkaListener;
-import com.oneul_tanda.flight_service.application.event.ReservationCanceledEvent;
+import com.oneul_tanda.flight_service.application.dtos.event.ReservationCanceledEvent;
 import com.oneul_tanda.flight_service.application.service.flight.FlightService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/event/FlightEventKafkaListenerImpl.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/event/FlightEventKafkaListenerImpl.java
@@ -1,0 +1,30 @@
+package com.oneul_tanda.flight_service.infrastructure.event;
+
+import com.oneul_tanda.flight_service.application.event.FlightEventKafkaListener;
+import com.oneul_tanda.flight_service.application.event.ReservationCanceledEvent;
+import com.oneul_tanda.flight_service.application.service.flight.FlightService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FlightEventKafkaListenerImpl implements FlightEventKafkaListener {
+
+    private final FlightService flightService;
+
+    // 예약 취소 이벤트 수신
+    @KafkaListener(
+            topics = "payment-canceled",
+            groupId = "flight-service",
+            containerFactory = "paymentCanceledListenerFactory"
+    )
+    public void consumePaymentCanceledFromPayment(ReservationCanceledEvent event) {
+        log.info("Received ReservationCanceledEvent From Payment: {}", event);
+        ReservationCanceledEvent.Data data = event.getData();
+        // 항공편 예약 취소(결제 취소)시 좌석 수 증가
+        flightService.increaseSeatsV2(event.getEventId(), data.getFlightId(), data.getSeatCount());
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/event/FlightEventKafkaProducerImpl.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/event/FlightEventKafkaProducerImpl.java
@@ -1,7 +1,7 @@
 package com.oneul_tanda.flight_service.infrastructure.event;
 
 import com.oneul_tanda.flight_service.application.event.FlightEventKafkaProducer;
-import com.oneul_tanda.flight_service.application.event.ReservationCanceledEvent;
+import com.oneul_tanda.flight_service.application.dtos.event.ReservationCanceledEvent;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/event/FlightEventKafkaProducerImpl.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/event/FlightEventKafkaProducerImpl.java
@@ -1,0 +1,25 @@
+package com.oneul_tanda.flight_service.infrastructure.event;
+
+import com.oneul_tanda.flight_service.application.event.FlightEventKafkaProducer;
+import com.oneul_tanda.flight_service.application.event.ReservationCanceledEvent;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FlightEventKafkaProducerImpl implements FlightEventKafkaProducer {
+
+    private final KafkaTemplate<String, ReservationCanceledEvent> kafkaTemplate;
+
+    public void sendFlightSeatRecovered(UUID reservationId, UUID flightId, Integer seatCount) {
+        ReservationCanceledEvent event = ReservationCanceledEvent
+                .of(reservationId, flightId, seatCount, "flight-seatRecovered");
+        kafkaTemplate.send("flight-seatRecovered", reservationId.toString(), event);
+
+        log.info("Sending ReservationCanceledEvent to Kafka: {}", event);
+    }
+}

--- a/flight-service/src/main/resources/application.yml
+++ b/flight-service/src/main/resources/application.yml
@@ -36,7 +36,6 @@ spring:
         spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
         spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
         allow.auto.create.topics: true
-        spring.json.trusted.packages: "*"
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/flight-service/src/main/resources/application.yml
+++ b/flight-service/src/main/resources/application.yml
@@ -26,6 +26,19 @@ spring:
       host: redis
       port: 6379
 
+  kafka:
+    bootstrap-servers: kafka:29092
+    consumer:
+      group-id: flight-service
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        allow.auto.create.topics: true
+        spring.json.trusted.packages: "*"
+
+
 amadeus:
   base-url: https://test.api.amadeus.com
   client-id: ${AMADEUS_CLIENT_ID}

--- a/flight-service/src/main/resources/application.yml
+++ b/flight-service/src/main/resources/application.yml
@@ -37,6 +37,9 @@ spring:
         spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
         allow.auto.create.topics: true
         spring.json.trusted.packages: "*"
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
 
 amadeus:


### PR DESCRIPTION
## 💡 이슈
resolve #115 

## 🤩 개요
kafka를 통한 좌석 복구 비동기 처리 increaseSeatsV2 추가

## 🧑‍💻 작업 사항
- kafka producer 및 consumer 설정
- 결제 서비스에서 결제취소 이벤트 받아 좌석 복구
- 좌석 복구 후, 예약 서비스로 이벤트 발행
- 좌석 차감 및 복구 커스텀 예외 처리

## 📖 참고 사항
재시도 및 DLQ 설정 추가 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 항공편 서비스에 Kafka 기반 이벤트 연동이 추가되어, 예약 취소 시 좌석 복구 이벤트를 비동기적으로 처리합니다.
    - Kafka 메시지 송수신을 위한 설정 및 구성(Producer/Consumer)이 도입되었습니다.

- **버그 수정**
    - 좌석 증감 시 예외 처리 방식이 커스텀 예외로 변경되어 오류 발생 시 일관된 처리가 가능합니다.

- **환경설정**
    - Kafka 연동을 위한 환경설정 및 의존성이 추가되었습니다.
    - Docker Compose에 Kafka 서비스 의존성이 명시되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->