### PR TITLE
Feat/#121 reservation-service 예약 기능 버전 분리

### DIFF
--- a/api-http-test/integration.http
+++ b/api-http-test/integration.http
@@ -32,7 +32,7 @@ Content-Type: application/json
 %}
 
 ### 항공편 조회 및 저장
-POST http://localhost:19091/api/v1/amadeus/flights/fetch-and-save?departureAirportCode=LGW&arrivalAirportCode=KWE&departureDate=2025-04-25T19:45:25&requiredSeats=2
+POST http://localhost:19091/api/v1/amadeus/flights/fetch-and-save?departureAirportCode=LGW&arrivalAirportCode=KWE&departureDate=2025-05-10T19:45:25&requiredSeats=2
 Authorization: Bearer {{access_token}}
 
 
@@ -42,7 +42,7 @@ Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 {
-  "flightId" : "66b08c46-8393-480a-a8bc-3d72dcda80dd",
+  "flightId" : "32c7b4bc-1abb-45e7-af42-6400487c0a8a",
   "seatCount" : 2
 }
 
@@ -55,12 +55,12 @@ Authorization: Bearer {{access_token}}
 
 
 ### 예약 확정 V2
-PUT http://localhost:19091/api/v1/reservations/confirm
+PUT http://localhost:19091/api/v1/reservations/confirmV2
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 {
-  "flightId": "57944490-33fb-4bb1-9254-1eae30a1a25c",
+  "flightId": "32c7b4bc-1abb-45e7-af42-6400487c0a8a",
   "passengers": [
     {
       "name": "홍길동1",
@@ -79,7 +79,7 @@ Authorization: Bearer {{access_token}}
 
 
 ### 예약 확정 V2, 결제 재시도
-PUT http://localhost:19091/api/v1/reservations/confirm
+PUT http://localhost:19091/api/v1/reservations/confirmV2
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
@@ -90,7 +90,7 @@ Authorization: Bearer {{access_token}}
 
 
 ### 예약 취소 V2
-PUT http://localhost:19091/api/v1/reservations/1c7204d2-c276-4d8e-8c9e-2446423deee4/cancelV2
+PUT http://localhost:19091/api/v1/reservations/c65b8f33-43df-43d1-956e-e1d0d5f9ec7c/cancelV2
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 

--- a/api-http-test/integration.http
+++ b/api-http-test/integration.http
@@ -89,6 +89,12 @@ Authorization: Bearer {{access_token}}
 
 
 
+### 예약 취소 V2
+PUT http://localhost:19091/api/v1/reservations/1c7204d2-c276-4d8e-8c9e-2446423deee4/cancelV2
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+
 
 ### 예약 단일 조회
 GET http://localhost:19091/api/v1/reservations/9b7f421f-47b0-47f5-aa5c-8f489697a57d

--- a/payment-service/src/main/java/com/sparta/paymentservice/infrastructure/kafka/config/KafkaConfig.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/infrastructure/kafka/config/KafkaConfig.java
@@ -50,8 +50,6 @@ public class KafkaConfig {
 
     @Bean
     public ConsumerFactory<String, ReservationCanceledEvent> reservationCanceledConsumerFactory() {
-
-        JsonDeserializer<ReservationCanceledEvent> jsonDeserializer = new JsonDeserializer<>(ReservationCanceledEvent.class);
         
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -67,7 +65,7 @@ public class KafkaConfig {
         configProps.put(JsonDeserializer.TRUSTED_PACKAGES,
                 "com.sparta.paymentservice.infrastructure.kafka.event");
 
-        return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(), jsonDeserializer);
+        return new DefaultKafkaConsumerFactory<>(configProps);
     }
 
     @Bean

--- a/payment-service/src/main/java/com/sparta/paymentservice/infrastructure/kafka/config/KafkaConfig.java
+++ b/payment-service/src/main/java/com/sparta/paymentservice/infrastructure/kafka/config/KafkaConfig.java
@@ -50,12 +50,14 @@ public class KafkaConfig {
     @Bean
     public ConsumerFactory<String, ReservationCanceledEvent> reservationCancelledConsumerFactory() {
 
+        JsonDeserializer<ReservationCanceledEvent> jsonDeserializer = new JsonDeserializer<>(ReservationCanceledEvent.class);
+        
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 
-        return new DefaultKafkaConsumerFactory<>(configProps);
+        return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(), jsonDeserializer);
     }
 
     @Bean

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommand.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommand.java
@@ -1,50 +1,7 @@
 package com.oneul_tanda.reservation_service.reservation.application.command;
 
-import com.oneul_tanda.reservation_service.reservation.domain.entity.vo.Gender;
-import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDto;
-
-import java.util.List;
-
 import java.util.UUID;
 
-public record ConfirmReservationCommand(
-        UUID userId,
-        UUID reservationId,
-        List<ConfirmTicketCommand> tickets
-) {
-    public static ConfirmReservationCommand of(UUID userId, UUID reservationId, ConfirmReservationRequestDto dto) {
-        return new ConfirmReservationCommand(
-                userId,
-                reservationId,
-                dto.tickets().stream()
-                        .map(ConfirmTicketCommand::from)
-                        .toList()
-        );
-    }
-
-
-
-    public record ConfirmTicketCommand(
-            UUID ticketId,
-            ConfirmPassengerCommand passenger
-    ) {
-        public static ConfirmTicketCommand from(ConfirmReservationRequestDto.ConfirmTicketDto dto) {
-            return new ConfirmTicketCommand(dto.ticketId(), ConfirmPassengerCommand.from(dto.passenger()));
-        }
-    }
-
-
-
-    public record ConfirmPassengerCommand(
-            String name,
-            String birth,
-            Gender gender,
-            String passportNumber
-    ) {
-        public static ConfirmPassengerCommand from(ConfirmReservationRequestDto.ConfirmPassengerDto dto) {
-            return new ConfirmPassengerCommand(dto.name(), dto.birth(), dto.gender(), dto.passportNumber());
-        }
-    }
+public interface ConfirmReservationCommand {
+    UUID userId();
 }
-
-

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommandV1.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommandV1.java
@@ -1,0 +1,50 @@
+package com.oneul_tanda.reservation_service.reservation.application.command;
+
+import com.oneul_tanda.reservation_service.reservation.domain.entity.vo.Gender;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDto;
+
+import java.util.List;
+
+import java.util.UUID;
+
+public record ConfirmReservationCommandV1(
+        UUID userId,
+        UUID reservationId,
+        List<ConfirmTicketCommand> tickets
+) implements ConfirmReservationCommand {
+    public static ConfirmReservationCommandV1 of(UUID userId, UUID reservationId, ConfirmReservationRequestDto dto) {
+        return new ConfirmReservationCommandV1(
+                userId,
+                reservationId,
+                dto.tickets().stream()
+                        .map(ConfirmTicketCommand::from)
+                        .toList()
+        );
+    }
+
+
+
+    public record ConfirmTicketCommand(
+            UUID ticketId,
+            ConfirmPassengerCommand passenger
+    ) {
+        public static ConfirmTicketCommand from(ConfirmReservationRequestDto.ConfirmTicketDto dto) {
+            return new ConfirmTicketCommand(dto.ticketId(), ConfirmPassengerCommand.from(dto.passenger()));
+        }
+    }
+
+
+
+    public record ConfirmPassengerCommand(
+            String name,
+            String birth,
+            Gender gender,
+            String passportNumber
+    ) {
+        public static ConfirmPassengerCommand from(ConfirmReservationRequestDto.ConfirmPassengerDto dto) {
+            return new ConfirmPassengerCommand(dto.name(), dto.birth(), dto.gender(), dto.passportNumber());
+        }
+    }
+}
+
+

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommandV2.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/command/ConfirmReservationCommandV2.java
@@ -10,7 +10,7 @@ public record ConfirmReservationCommandV2(
         UUID userId,
         UUID flightId,
         List<PassengerDto> passengers
-) {
+) implements ConfirmReservationCommand {
     public static ConfirmReservationCommandV2 of(UUID userId, ConfirmReservationRequestDtoV2 dto) {
         return new ConfirmReservationCommandV2(
                 userId,

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/exception/ReservationErrorCode.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/exception/ReservationErrorCode.java
@@ -40,10 +40,9 @@ public enum ReservationErrorCode implements ErrorCode {
 
   HOLD_RESERVATION_EXPIRED("임시 예약이 만료되었습니다. 다시 예약을 시도해주세요.", HttpStatus.BAD_REQUEST),
   REDIS_SAVE_FAILED("Redis 저장에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-  REDIS_LOAD_FAILED("Redis 데이터 읽기에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+  REDIS_LOAD_FAILED("Redis 데이터 읽기에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
-
-
+  INVALID_COMMAND_TYPE("잘못된 예약 확정 요청 타입입니다.", HttpStatus.BAD_REQUEST);
 
 
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationService.java
@@ -1,14 +1,12 @@
 package com.oneul_tanda.reservation_service.reservation.application.service;
 
 import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
-import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.DeleteReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
-import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDtoV2;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
 import org.springframework.data.domain.Page;
@@ -20,8 +18,6 @@ public interface ReservationService {
 
     CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command);
 
-    void createHoldReservationV2(CreateHoldReservationCommand command);
-
     CreateReservationResponseDto createReservation(CreateReservationCommand command);
 
     ReadReservationResponseDto readReservation(UUID reservationId);
@@ -30,11 +26,7 @@ public interface ReservationService {
 
     ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand command);
 
-    ConfirmReservationResponseDto confirmReservationV2(ConfirmReservationCommandV2 command);
-
     CancelReservationResponseDto cancelReservation(UUID reservationId);
-
-    CancelReservationResponseDtoV2 cancelReservationV2(UUID reservationId);
 
     void cancelReservationConfirm(UUID reservationId);
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/ReservationServiceImpl.java
@@ -1,29 +1,21 @@
 package com.oneul_tanda.reservation_service.reservation.application.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneul_tanda.reservation_service.common.exception.CustomException;
-import com.oneul_tanda.reservation_service.reservation.domain.entity.Passenger;
-import com.oneul_tanda.reservation_service.reservation.application.dto.HoldReservationData;
-import com.oneul_tanda.reservation_service.reservation.application.dto.PassengerDto;
-import com.oneul_tanda.reservation_service.reservation.application.client.FlightClient;
-import com.oneul_tanda.reservation_service.reservation.application.client.PaymentClient;
-import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.PaymentInfo;
 import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
-import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
+import com.oneul_tanda.reservation_service.reservation.application.service.strategy.ReservationStrategy;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Passenger;
+import com.oneul_tanda.reservation_service.reservation.application.client.FlightClient;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.exception.ReservationErrorCode;
 import com.oneul_tanda.reservation_service.reservation.domain.entity.Reservation;
 import com.oneul_tanda.reservation_service.reservation.domain.repository.ReservationRepository;
 import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.GetFlightInfo;
-import com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.KafkaReservationProducer;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.DeleteReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
-import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDtoV2;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.domain.entity.vo.SeatClass;
 import com.oneul_tanda.reservation_service.reservation.domain.entity.Ticket;
@@ -31,11 +23,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -46,12 +36,9 @@ import java.util.UUID;
 @Transactional
 public class ReservationServiceImpl implements ReservationService {
 
+    private final ReservationStrategy reservationStrategy;
     private final ReservationRepository reservationRepository;
     private final FlightClient flightClient;
-    private final PaymentClient paymentClient;
-    private final RedisTemplate<String, String> redisTemplate;
-    private final ObjectMapper objectMapper;
-    private final KafkaReservationProducer producer;
 
 
     /**
@@ -81,61 +68,12 @@ public class ReservationServiceImpl implements ReservationService {
 
 
     /**
-     * 예약 임시 생성 V1
+     * 예약 임시 생성
      */
     @Override
     public CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command) {
-
-        // 중복 예약 생성 검증
-        validateDuplicateReservation(command.userId(), command.flightId());
-
-        // FeignClient 항공편 조회 및 데이터 획득
-        GetFlightInfo flightInfo = flightClient.getFlight(command.flightId());
-
-        // 티켓 임시 생성 (탑승객 정보x)
-        List<Ticket> ticketList = createTicketsWithoutPassengers(command, flightInfo);
-
-        // 예약 임시 생성
-        Reservation reservation = Reservation.createHoldReservation(command.userId(), ticketList);
-
-        return CreateHoldReservationResponseDto.from(reservationRepository.save(reservation));
+        return reservationStrategy.createHoldReservation(command);
     }
-
-
-
-    /**
-     * 예약 임시 생성 V2
-     */
-    @Override
-    public void createHoldReservationV2(CreateHoldReservationCommand command) {
-
-        UUID flightId = command.flightId();
-        UUID userId = command.userId();
-        int seatCount = command.seatCount();
-
-        String key = "HoldReservation:" + flightId + ":" + userId;
-
-        // 중복 임시 예약 생성 검증
-        validateDuplicateHoldReservation(key);
-
-        // 임시 예약 데이터 생성
-        HoldReservationData holdData = HoldReservationData.of(seatCount, new ArrayList<>());
-
-        // 임시 예약 데이터 Redis에 저장
-        try {
-            String value = objectMapper.writeValueAsString(holdData);
-            redisTemplate.opsForValue().set(key, value, Duration.ofMinutes(2));
-            log.info("임시 예약 생성 완료: {}", key);
-
-        } catch (JsonProcessingException e) {
-            log.error("임시 예약 저장 실패: {}", e.getMessage(), e);
-            // Todo 좌석 복구 or 알림 시스템에 예약 임시 생성 실패 전송
-            throw new CustomException(ReservationErrorCode.REDIS_SAVE_FAILED);
-        }
-
-        // Todo 예약 임시 생성 완료 이벤트 발행 or 알림 시스템에 예약 임시 생성 완료 전송
-    }
-
 
 
 
@@ -164,111 +102,13 @@ public class ReservationServiceImpl implements ReservationService {
 
 
 
-
     /**
-     * 예약 확정 V1 (1.탑승객 정보 입력 + 2.결제 -> 예약 확정)
+     * 예약 확정
      */
     @Override
     public ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand command) {
-        // 예약 조회
-        Reservation reservation = getReservationOrThrow(command.reservationId());
-
-        // 1. 탑승객 정보 입력 (티켓에 탑승객 정보 매핑)
-        if (reservation.isPassengerInfoInputPossible()) {
-            registerPassengerInfo(command, reservation);
-            reservation.completePassengerInfo();
-            reservationRepository.save(reservation);
-        }
-
-        // 2. 결제 요청
-        PaymentInfo paymentInfo = requestPayment(reservation);
-
-        // 결제 실패 처리
-        if (paymentInfo == null || !paymentInfo.status().equalsIgnoreCase("PAID")) {
-            reservation.completePaymentFailure();
-            reservationRepository.save(reservation);
-            throw new CustomException(ReservationErrorCode.PAYMENT_FAILED);
-        }
-
-        // 결제 성공 -> 예약 확정 처리
-        reservation.confirmReservation();
-        reservationRepository.save(reservation);
-
-        return ConfirmReservationResponseDto.from(reservation);
+        return reservationStrategy.confirmReservation(command);
     }
-
-
-
-
-    /**
-     * 예약 확정 V2 (1.임시 예약 조회 및 검증 -> 2.탑승객 정보 입력 -> 3.예약 생성 -> 4.결제 -> 5.예약 확정)
-     */
-    @Override
-    public ConfirmReservationResponseDto confirmReservationV2(ConfirmReservationCommandV2 command) {
-
-        UUID flightId = command.flightId();
-        UUID userId = command.userId();
-        String key = "HoldReservation:" + flightId + ":" + userId;
-        List<PassengerDto> passengers;
-
-
-        // 1. Redis에서 임시 예약 조회 및 검증
-        HoldReservationData holdData = validateAndGetHoldReservation(key);
-        log.info("임시 예약 조회: {}", holdData);
-
-
-
-        // 2. 탑승객 정보 입력
-        if (command.passengers() != null && !command.passengers().isEmpty()) {
-            // 탑승객 정보가 요청에 있으면 (사용자가 처음 요청할 때)
-            passengers = command.passengers();
-            holdData = HoldReservationData.of(holdData.seatCount(), passengers);
-
-            try {
-                String updatedValue = objectMapper.writeValueAsString(holdData);
-                redisTemplate.opsForValue().set(key, updatedValue, Duration.ofMinutes(5));
-            } catch (JsonProcessingException e) {
-                log.error("Redis 탑승객 정보 업데이트 실패: {}", e.getMessage(), e);
-                throw new CustomException(ReservationErrorCode.REDIS_SAVE_FAILED);
-            }
-
-
-        } else {
-            // 탑승객 정보가 요청에 없으면 (결제 실패 후, 재시도할 때 -> Redis에 있는 탑승객 정보 사용)
-            if (holdData.passengers() == null || holdData.passengers().isEmpty()) {
-                throw new CustomException(ReservationErrorCode.PASSENGERS_NOT_FOUND);
-            }
-            passengers = holdData.passengers();
-        }
-
-
-
-        // 3. 예약 생성
-        GetFlightInfo flightInfo = flightClient.getFlight(flightId);
-        List<Ticket> ticketList = createTicketsFromHoldData(userId, flightInfo, passengers);
-        Reservation reservation = Reservation.createReservation(userId, ticketList);
-        reservationRepository.save(reservation);
-
-
-        // 4. 결제 요청
-        PaymentInfo paymentInfo = requestPayment(reservation);
-        if (paymentInfo == null || !"PAID".equalsIgnoreCase(paymentInfo.status())) {
-            throw new CustomException(ReservationErrorCode.PAYMENT_FAILED);
-        }
-
-
-        // 5. 결제 성공 -> 예약 확정
-        reservation.confirmReservation();
-        reservationRepository.save(reservation);
-
-        // Redis 키 삭제
-        redisTemplate.delete(key);
-
-        return ConfirmReservationResponseDto.from(reservation);
-    }
-
-
-
 
 
 
@@ -278,66 +118,8 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public CancelReservationResponseDto cancelReservation(UUID reservationId) {
-        // 예약 조회
-        Reservation reservation = getReservationOrThrow(reservationId);
-
-        try {
-            // 1. 좌석 복구
-            restoreReservedSeats(reservation);
-
-            // 2. 결제 취소(환불) 요청
-            cancelPayment(reservation);
-
-            // 3. 예약 취소
-            reservation.cancel();
-
-            return CancelReservationResponseDto.of(reservation.getId());
-
-        } catch (CustomException e) {
-
-            // 좌석 복구 자체 실패 -> 보상 필요 없음
-            if (e.getErrorCode() == ReservationErrorCode.FLIGHT_SEAT_RESTORE_FAILED) {
-                log.warn("좌석 복구 실패 - 보상 생략");
-                throw e;
-            }
-
-            // 좌석 복구는 성공, 결제 취소 실패 -> 보상 트랜잭션 수행
-            try {
-                log.warn("결제 취소 실패 - 보상 트랜잭션 수행");
-                compensateReservedSeats(reservation); // 좌석 복구 롤백 -> 다시 차감
-            } catch (Exception rollbackEx) {
-                log.error("좌석 복구 보상(롤백) 실패 - 수동 조치 필요: flightId={}, error={}",
-                        reservation.getTicketList().get(0).getFlightId(), rollbackEx.getMessage(), rollbackEx);
-                // TODO: Slack 알림, DLQ 등
-            }
-            throw e;
-        }
-
+        return reservationStrategy.cancelReservation(reservationId);
     }
-
-
-
-    /**
-     * 예약 취소 V2
-     */
-    @Override
-    @Transactional
-    public CancelReservationResponseDtoV2 cancelReservationV2(UUID reservationId) {
-        // 1. 예약 조회
-        Reservation reservation = getReservationOrThrow(reservationId);
-
-        // 2. 예약 취소
-        reservation.requestCancellation();
-
-        // 3. 이벤트 발행
-        UUID flightId = reservation.getTicketList().get(0).getFlightId();
-        int seatCount = reservation.getTicketList().size();
-        producer.sendReservationCanceledEvent(reservation.getId(), flightId, reservation.getUserId(), seatCount);
-
-        // 4. 응답 반환
-        return CancelReservationResponseDtoV2.of(reservation.getId());
-    }
-
 
 
 
@@ -407,158 +189,10 @@ public class ReservationServiceImpl implements ReservationService {
         return ticketList;
     }
 
-    // userId, flightInfo, Redis passengers 기반 티켓 리스트 생성
-    private List<Ticket> createTicketsFromHoldData(UUID userId, GetFlightInfo flightInfo, List<PassengerDto> passengers) {
-
-        List<Ticket> tickets = new ArrayList<>();
-
-        for (PassengerDto p : passengers) {
-            Passenger passenger = Passenger.createPassenger(
-                    userId,
-                    p.name(),
-                    p.birth(),
-                    p.gender(),
-                    p.passportNumber()
-            );
-
-            Ticket ticket = Ticket.createTicket(
-                    passenger,
-                    flightInfo.id(),
-                    userId,
-                    SeatClass.ECONOMY,
-                    flightInfo.price(),
-                    flightInfo.departureDate(),
-                    flightInfo.arrivalDate()
-            );
-
-            tickets.add(ticket);
-        }
-        return tickets;
-    }
-
-
-    // 티켓 임시 생성
-    private List<Ticket> createTicketsWithoutPassengers(CreateHoldReservationCommand command, GetFlightInfo flightInfo) {
-
-        List<Ticket> ticketList = new ArrayList<>();
-
-        for (int i = 0; i < command.seatCount(); i++) {
-            Ticket ticket = Ticket.createTicketWithoutPassenger(
-                    command.flightId(),
-                    command.userId(),
-                    SeatClass.ECONOMY,
-                    flightInfo.price(),
-                    flightInfo.departureDate(),
-                    flightInfo.arrivalDate()
-            );
-            ticketList.add(ticket);
-        }
-
-        return ticketList;
-    }
-
-
-    // 탑승객 정보 입력(티켓 확정)
-    private void registerPassengerInfo(ConfirmReservationCommand command, Reservation reservation) {
-
-        for (ConfirmReservationCommand.ConfirmTicketCommand ticketCommand : command.tickets()) {
-            // 예약 내에서 특정 티켓 조회 및 존재 여부 검증
-            Ticket ticket = validateAndGetTicket(reservation, ticketCommand);
-
-            // 탑승객 생성
-            Passenger passenger = Passenger.createPassenger(
-                    command.userId(),
-                    ticketCommand.passenger().name(),
-                    ticketCommand.passenger().birth(),
-                    ticketCommand.passenger().gender(),
-                    ticketCommand.passenger().passportNumber()
-            );
-
-            // 티켓에 탑승객 정보 매핑
-            ticket.confirmTicket(passenger);
-        }
-    }
-
-
-    // 결제 요청
-    public PaymentInfo requestPayment(Reservation reservation) {
-
-        // 결제 가능 상태 검증
-        if (!reservation.isPayable()) {
-            throw new CustomException(ReservationErrorCode.PAYMENT_NOT_ALLOWED);
-        }
-
-        // 결제 요청
-        try {
-            return paymentClient.confirmPayment(
-                    reservation.getId(),
-                    reservation.getTotalPrice()
-            );
-
-        } catch (Exception e) {
-            log.error("결제 예외 발생 - ReservationId: {}", reservation.getId(), e);
-            return null;
-        }
-    }
-
-
-    // 선점된 좌석 복구
-    private void restoreReservedSeats(Reservation reservation) {
-
-        Integer seatCount = reservation.getTicketList().size();
-        UUID flightId = reservation.getTicketList().get(0).getFlightId();
-
-        // 좌석 복구 요청
-        // TODO: 분산 트랜잭션 어떻게 관리? 1. Saga 패턴의 보상트랜잭션,  2. 이벤트 발행, 3. 기타
-        try {
-            flightClient.increaseSeats(flightId, seatCount);
-
-        } catch (Exception e) {
-            log.error("좌석 복원 실패 - flightId={}, seatCounts={}, error={}", flightId, seatCount, e.getMessage(), e);
-            throw CustomException.from(ReservationErrorCode.FLIGHT_SEAT_RESTORE_FAILED);
-        }
-    }
-
-
-    // 결제 취소(환불) 요청
-    private void cancelPayment(Reservation reservation) {
-        try {
-            paymentClient.cancelPayment(reservation.getId());
-
-        } catch (Exception e) {
-            log.error("결제 취소 실패 - reservationId={}, error={}", reservation.getId(), e.getMessage(), e);
-            throw CustomException.from(ReservationErrorCode.PAYMENT_REFUND_FAILED);
-        }
-    }
-
-
-    // 보상 트랜잭션: 좌석 차감 보상(복구 취소)
-    private void compensateReservedSeats(Reservation reservation) {
-        Integer seatCount = reservation.getTicketList().size();
-        UUID flightId = reservation.getTicketList().get(0).getFlightId();
-
-        try {
-            flightClient.decreaseSeats(flightId, seatCount);
-        } catch (Exception e) {
-            log.error("좌석 차감 보상 실패 - flightId={}, seatCount={}, error={}",
-                    flightId, seatCount, e.getMessage(), e);
-            throw CustomException.from(ReservationErrorCode.FLIGHT_SEAT_COMPENSATION_FAILED);
-        }
-    }
-
 
 
 
     // === 검증 메서드 === //
-    // 예약 내에서 특정 티켓 조회 및 존재 여부 검증
-    private Ticket validateAndGetTicket(Reservation reservation, ConfirmReservationCommand.ConfirmTicketCommand ticketCommand) {
-        return reservation.getTicketList().stream()
-                .filter(t -> t.getId().equals(ticketCommand.ticketId()))
-                .findFirst()
-                .orElseThrow(() -> CustomException.from(ReservationErrorCode.TICKET_NOT_FOUND));
-    }
-
-
     // 중복 예약 생성 검증
     private void validateDuplicateReservation(UUID userId, UUID flightId) {
         if (reservationRepository.findByUserIdAndFlightId(userId, flightId).isPresent()) {
@@ -574,31 +208,4 @@ public class ReservationServiceImpl implements ReservationService {
         }
         flightClient.decreaseSeats(command.flightId(), command.seatCount());
     }
-
-
-    // 중복 임시 예약 생성 검증
-    private void validateDuplicateHoldReservation(String key) {
-        if (redisTemplate.hasKey(key)) {
-            throw CustomException.from(ReservationErrorCode.RESERVATION_DUPLICATE);
-        }
-    }
-
-
-    // Redis에서 임시 예약 조회 및 검증
-    private HoldReservationData validateAndGetHoldReservation(String key) {
-
-        String value = redisTemplate.opsForValue().get(key);
-        if (value == null) {
-            throw new CustomException(ReservationErrorCode.HOLD_RESERVATION_EXPIRED);
-        }
-
-        try {
-            return objectMapper.readValue(value, HoldReservationData.class);
-        } catch (JsonProcessingException e) {
-            log.error("Redis 데이터 역직렬화 실패: {}", e.getMessage(), e);
-            throw new CustomException(ReservationErrorCode.REDIS_LOAD_FAILED);
-        }
-    }
-
-
 }

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/strategy/ReservationStrategy.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/strategy/ReservationStrategy.java
@@ -1,0 +1,18 @@
+package com.oneul_tanda.reservation_service.reservation.application.service.strategy;
+
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
+
+import java.util.UUID;
+
+public interface ReservationStrategy {
+
+    CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command);
+
+    ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand command);
+
+    CancelReservationResponseDto cancelReservation(UUID reservationId);
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/strategy/ReservationStrategyV1.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/strategy/ReservationStrategyV1.java
@@ -1,0 +1,285 @@
+package com.oneul_tanda.reservation_service.reservation.application.service.strategy;
+
+import com.oneul_tanda.reservation_service.common.exception.CustomException;
+import com.oneul_tanda.reservation_service.reservation.application.client.FlightClient;
+import com.oneul_tanda.reservation_service.reservation.application.client.PaymentClient;
+import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.GetFlightInfo;
+import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.PaymentInfo;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV1;
+import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.exception.ReservationErrorCode;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Passenger;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Reservation;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Ticket;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.vo.SeatClass;
+import com.oneul_tanda.reservation_service.reservation.domain.repository.ReservationRepository;
+
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service("reservationStrategyV1")
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class ReservationStrategyV1 implements ReservationStrategy {
+
+
+    private final ReservationRepository reservationRepository;
+    private final FlightClient flightClient;
+    private final PaymentClient paymentClient;
+
+
+    /**
+     * 예약 임시 생성 V1
+     */
+    @Override
+    public CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command) {
+
+        // 중복 예약 생성 검증
+        validateDuplicateReservation(command.userId(), command.flightId());
+
+        // FeignClient 항공편 조회 및 데이터 획득
+        GetFlightInfo flightInfo = flightClient.getFlight(command.flightId());
+
+        // 티켓 임시 생성 (탑승객 정보x)
+        List<Ticket> ticketList = createTicketsWithoutPassengers(command, flightInfo);
+
+        // 예약 임시 생성
+        Reservation reservation = Reservation.createHoldReservation(command.userId(), ticketList);
+
+        return CreateHoldReservationResponseDto.from(reservationRepository.save(reservation));
+    }
+
+
+
+    /**
+     * 예약 확정 V1 (1.탑승객 정보 입력 + 2.결제 -> 예약 확정)
+     */
+    @Override
+    public ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand commandV1) {
+
+        if (!(commandV1 instanceof ConfirmReservationCommandV1 command)) {
+            throw new CustomException(ReservationErrorCode.INVALID_COMMAND_TYPE);
+        }
+
+        // 예약 조회
+        Reservation reservation = getReservationOrThrow(command.reservationId());
+
+        // 1. 탑승객 정보 입력 (티켓에 탑승객 정보 매핑)
+        if (reservation.isPassengerInfoInputPossible()) {
+            registerPassengerInfo(command, reservation);
+            reservation.completePassengerInfo();
+            reservationRepository.save(reservation);
+        }
+
+        // 2. 결제 요청
+        PaymentInfo paymentInfo = requestPayment(reservation);
+
+        // 결제 실패 처리
+        if (paymentInfo == null || !paymentInfo.status().equalsIgnoreCase("PAID")) {
+            reservation.completePaymentFailure();
+            reservationRepository.save(reservation);
+            throw new CustomException(ReservationErrorCode.PAYMENT_FAILED);
+        }
+
+        // 결제 성공 -> 예약 확정 처리
+        reservation.confirmReservation();
+        reservationRepository.save(reservation);
+
+        return ConfirmReservationResponseDto.from(reservation);
+    }
+
+
+
+    /**
+     * 예약 취소
+     */
+    @Override
+    @Transactional
+    public CancelReservationResponseDto cancelReservation(UUID reservationId) {
+        // 예약 조회
+        Reservation reservation = getReservationOrThrow(reservationId);
+
+        try {
+            // 1. 좌석 복구
+            restoreReservedSeats(reservation);
+
+            // 2. 결제 취소(환불) 요청
+            cancelPayment(reservation);
+
+            // 3. 예약 취소
+            reservation.cancel();
+
+            return CancelReservationResponseDto.of(reservation.getId());
+
+        } catch (CustomException e) {
+
+            // 좌석 복구 자체 실패 -> 보상 필요 없음
+            if (e.getErrorCode() == ReservationErrorCode.FLIGHT_SEAT_RESTORE_FAILED) {
+                log.warn("좌석 복구 실패 - 보상 생략");
+                throw e;
+            }
+
+            // 좌석 복구는 성공, 결제 취소 실패 -> 보상 트랜잭션 수행
+            try {
+                log.warn("결제 취소 실패 - 보상 트랜잭션 수행");
+                compensateReservedSeats(reservation); // 좌석 복구 롤백 -> 다시 차감
+            } catch (Exception rollbackEx) {
+                log.error("좌석 복구 보상(롤백) 실패 - 수동 조치 필요: flightId={}, error={}",
+                        reservation.getTicketList().get(0).getFlightId(), rollbackEx.getMessage(), rollbackEx);
+                // TODO: Slack 알림, DLQ 등
+            }
+            throw e;
+        }
+
+    }
+
+
+
+    // 예약 조회
+    private Reservation getReservationOrThrow(UUID reservationId) {
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> CustomException.from(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+
+    // 티켓 임시 생성
+    private List<Ticket> createTicketsWithoutPassengers(CreateHoldReservationCommand command, GetFlightInfo flightInfo) {
+
+        List<Ticket> ticketList = new ArrayList<>();
+
+        for (int i = 0; i < command.seatCount(); i++) {
+            Ticket ticket = Ticket.createTicketWithoutPassenger(
+                    command.flightId(),
+                    command.userId(),
+                    SeatClass.ECONOMY,
+                    flightInfo.price(),
+                    flightInfo.departureDate(),
+                    flightInfo.arrivalDate()
+            );
+            ticketList.add(ticket);
+        }
+
+        return ticketList;
+    }
+
+
+    // 탑승객 정보 입력(티켓 확정)
+    private void registerPassengerInfo(ConfirmReservationCommandV1 command, Reservation reservation) {
+
+        for (ConfirmReservationCommandV1.ConfirmTicketCommand ticketCommand : command.tickets()) {
+            // 예약 내에서 특정 티켓 조회 및 존재 여부 검증
+            Ticket ticket = validateAndGetTicket(reservation, ticketCommand);
+
+            // 탑승객 생성
+            Passenger passenger = Passenger.createPassenger(
+                    command.userId(),
+                    ticketCommand.passenger().name(),
+                    ticketCommand.passenger().birth(),
+                    ticketCommand.passenger().gender(),
+                    ticketCommand.passenger().passportNumber()
+            );
+
+            // 티켓에 탑승객 정보 매핑
+            ticket.confirmTicket(passenger);
+        }
+    }
+
+
+    // 결제 요청
+    public PaymentInfo requestPayment(Reservation reservation) {
+
+        // 결제 가능 상태 검증
+        if (!reservation.isPayable()) {
+            throw new CustomException(ReservationErrorCode.PAYMENT_NOT_ALLOWED);
+        }
+
+        // 결제 요청
+        try {
+            return paymentClient.confirmPayment(
+                    reservation.getId(),
+                    reservation.getTotalPrice()
+            );
+
+        } catch (Exception e) {
+            log.error("결제 예외 발생 - ReservationId: {}", reservation.getId(), e);
+            return null;
+        }
+    }
+
+
+    // 선점된 좌석 복구
+    private void restoreReservedSeats(Reservation reservation) {
+
+        Integer seatCount = reservation.getTicketList().size();
+        UUID flightId = reservation.getTicketList().get(0).getFlightId();
+
+        // 좌석 복구 요청
+        // TODO: 분산 트랜잭션 어떻게 관리? 1. Saga 패턴의 보상트랜잭션,  2. 이벤트 발행, 3. 기타
+        try {
+            flightClient.increaseSeats(flightId, seatCount);
+
+        } catch (Exception e) {
+            log.error("좌석 복원 실패 - flightId={}, seatCounts={}, error={}", flightId, seatCount, e.getMessage(), e);
+            throw CustomException.from(ReservationErrorCode.FLIGHT_SEAT_RESTORE_FAILED);
+        }
+    }
+
+
+    // 결제 취소(환불) 요청
+    private void cancelPayment(Reservation reservation) {
+        try {
+            paymentClient.cancelPayment(reservation.getId());
+
+        } catch (Exception e) {
+            log.error("결제 취소 실패 - reservationId={}, error={}", reservation.getId(), e.getMessage(), e);
+            throw CustomException.from(ReservationErrorCode.PAYMENT_REFUND_FAILED);
+        }
+    }
+
+
+    // 보상 트랜잭션: 좌석 차감 보상(복구 취소)
+    private void compensateReservedSeats(Reservation reservation) {
+        Integer seatCount = reservation.getTicketList().size();
+        UUID flightId = reservation.getTicketList().get(0).getFlightId();
+
+        try {
+            flightClient.decreaseSeats(flightId, seatCount);
+        } catch (Exception e) {
+            log.error("좌석 차감 보상 실패 - flightId={}, seatCount={}, error={}",
+                    flightId, seatCount, e.getMessage(), e);
+            throw CustomException.from(ReservationErrorCode.FLIGHT_SEAT_COMPENSATION_FAILED);
+        }
+    }
+
+
+
+
+    // === 검증 메서드 === //
+    // 예약 내에서 특정 티켓 조회 및 존재 여부 검증
+    private Ticket validateAndGetTicket(Reservation reservation, ConfirmReservationCommandV1.ConfirmTicketCommand ticketCommand) {
+        return reservation.getTicketList().stream()
+                .filter(t -> t.getId().equals(ticketCommand.ticketId()))
+                .findFirst()
+                .orElseThrow(() -> CustomException.from(ReservationErrorCode.TICKET_NOT_FOUND));
+    }
+
+
+    // 중복 예약 생성 검증
+    private void validateDuplicateReservation(UUID userId, UUID flightId) {
+        if (reservationRepository.findByUserIdAndFlightId(userId, flightId).isPresent()) {
+            throw CustomException.from(ReservationErrorCode.RESERVATION_DUPLICATE);
+        }
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/strategy/ReservationStrategyV2.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/strategy/ReservationStrategyV2.java
@@ -91,11 +91,10 @@ public class ReservationStrategyV2 implements ReservationStrategy {
      */
     @Override
     public ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand commandV2) {
-        System.out.println("캐스팅: ");
+
         if (!(commandV2 instanceof ConfirmReservationCommandV2 command)) {
             throw new CustomException(ReservationErrorCode.INVALID_COMMAND_TYPE);
         }
-        System.out.println("캐스팅 후: ");
 
         UUID flightId = command.flightId();
         UUID userId = command.userId();

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/strategy/ReservationStrategyV2.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/application/service/strategy/ReservationStrategyV2.java
@@ -1,0 +1,276 @@
+package com.oneul_tanda.reservation_service.reservation.application.service.strategy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneul_tanda.reservation_service.common.exception.CustomException;
+import com.oneul_tanda.reservation_service.reservation.application.client.FlightClient;
+import com.oneul_tanda.reservation_service.reservation.application.client.PaymentClient;
+import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.GetFlightInfo;
+import com.oneul_tanda.reservation_service.reservation.application.client.dto.response.PaymentInfo;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
+import com.oneul_tanda.reservation_service.reservation.application.command.CreateHoldReservationCommand;
+import com.oneul_tanda.reservation_service.reservation.application.dto.HoldReservationData;
+import com.oneul_tanda.reservation_service.reservation.application.dto.PassengerDto;
+import com.oneul_tanda.reservation_service.reservation.application.exception.ReservationErrorCode;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Passenger;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Reservation;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.Ticket;
+import com.oneul_tanda.reservation_service.reservation.domain.entity.vo.SeatClass;
+import com.oneul_tanda.reservation_service.reservation.domain.repository.ReservationRepository;
+import com.oneul_tanda.reservation_service.reservation.infrastructure.kafka.KafkaReservationProducer;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateHoldReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+
+@Primary
+@Service("reservationStrategyV2")
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class ReservationStrategyV2 implements ReservationStrategy {
+
+    private final ReservationRepository reservationRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final FlightClient flightClient;
+    private final PaymentClient paymentClient;
+    private final KafkaReservationProducer producer;
+    private final ObjectMapper objectMapper;
+
+
+    /**
+     * 예약 임시 생성 V2
+     */
+    @Override
+    public CreateHoldReservationResponseDto createHoldReservation(CreateHoldReservationCommand command) {
+
+        UUID flightId = command.flightId();
+        UUID userId = command.userId();
+        int seatCount = command.seatCount();
+
+        String key = "HoldReservation:" + flightId + ":" + userId;
+
+        // 중복 임시 예약 생성 검증
+        validateDuplicateHoldReservation(key);
+
+        // 임시 예약 데이터 생성
+        HoldReservationData holdData = HoldReservationData.of(seatCount, new ArrayList<>());
+
+        // 임시 예약 데이터 Redis에 저장
+        try {
+            String value = objectMapper.writeValueAsString(holdData);
+            redisTemplate.opsForValue().set(key, value, Duration.ofMinutes(2));
+            log.info("임시 예약 생성 완료: {}", key);
+
+        } catch (JsonProcessingException e) {
+            log.error("임시 예약 저장 실패: {}", e.getMessage(), e);
+            // Todo 좌석 복구 or 알림 시스템에 예약 임시 생성 실패 전송
+            throw new CustomException(ReservationErrorCode.REDIS_SAVE_FAILED);
+        }
+
+        // Todo 예약 임시 생성 완료 이벤트 발행 or 알림 시스템에 예약 임시 생성 완료 전송
+        return null;
+    }
+
+
+
+    /**
+     * 예약 확정 V2 (1.임시 예약 조회 및 검증 -> 2.탑승객 정보 입력 -> 3.예약 생성 -> 4.결제 -> 5.예약 확정)
+     */
+    @Override
+    public ConfirmReservationResponseDto confirmReservation(ConfirmReservationCommand commandV2) {
+        System.out.println("캐스팅: ");
+        if (!(commandV2 instanceof ConfirmReservationCommandV2 command)) {
+            throw new CustomException(ReservationErrorCode.INVALID_COMMAND_TYPE);
+        }
+        System.out.println("캐스팅 후: ");
+
+        UUID flightId = command.flightId();
+        UUID userId = command.userId();
+        String key = "HoldReservation:" + flightId + ":" + userId;
+        List<PassengerDto> passengers;
+
+
+        // 1. Redis에서 임시 예약 조회 및 검증
+        HoldReservationData holdData = validateAndGetHoldReservation(key);
+        log.info("임시 예약 조회: {}", holdData);
+
+
+
+        // 2. 탑승객 정보 입력
+        if (command.passengers() != null && !command.passengers().isEmpty()) {
+            // 탑승객 정보가 요청에 있으면 (사용자가 처음 요청할 때)
+            passengers = command.passengers();
+            holdData = HoldReservationData.of(holdData.seatCount(), passengers);
+
+            try {
+                String updatedValue = objectMapper.writeValueAsString(holdData);
+                redisTemplate.opsForValue().set(key, updatedValue, Duration.ofMinutes(5));
+            } catch (JsonProcessingException e) {
+                log.error("Redis 탑승객 정보 업데이트 실패: {}", e.getMessage(), e);
+                throw new CustomException(ReservationErrorCode.REDIS_SAVE_FAILED);
+            }
+
+
+        } else {
+            // 탑승객 정보가 요청에 없으면 (결제 실패 후, 재시도할 때 -> Redis에 있는 탑승객 정보 사용)
+            if (holdData.passengers() == null || holdData.passengers().isEmpty()) {
+                throw new CustomException(ReservationErrorCode.PASSENGERS_NOT_FOUND);
+            }
+            passengers = holdData.passengers();
+        }
+
+
+
+        // 3. 예약 생성
+        GetFlightInfo flightInfo = flightClient.getFlight(flightId);
+        List<Ticket> ticketList = createTicketsFromHoldData(userId, flightInfo, passengers);
+        Reservation reservation = Reservation.createReservation(userId, ticketList);
+        reservationRepository.save(reservation);
+
+
+        // 4. 결제 요청
+        PaymentInfo paymentInfo = requestPayment(reservation);
+        if (paymentInfo == null || !"PAID".equalsIgnoreCase(paymentInfo.status())) {
+            throw new CustomException(ReservationErrorCode.PAYMENT_FAILED);
+        }
+
+
+        // 5. 결제 성공 -> 예약 확정
+        reservation.confirmReservation();
+        reservationRepository.save(reservation);
+
+        // Redis 키 삭제
+        redisTemplate.delete(key);
+
+        return ConfirmReservationResponseDto.from(reservation);
+    }
+
+
+
+    /**
+     * 예약 취소 V2
+     */
+    @Override
+    @Transactional
+    public CancelReservationResponseDto cancelReservation(UUID reservationId) {
+        // 1. 예약 조회
+        Reservation reservation = getReservationOrThrow(reservationId);
+
+        // 2. 예약 취소
+        reservation.requestCancellation();
+
+        // 3. 이벤트 발행
+        UUID flightId = reservation.getTicketList().get(0).getFlightId();
+        int seatCount = reservation.getTicketList().size();
+        producer.sendReservationCanceledEvent(reservation.getId(), flightId, reservation.getUserId(), seatCount);
+
+        // 4. 응답 반환
+        return CancelReservationResponseDto.of(reservation.getId());
+    }
+
+
+
+
+    // 예약 조회
+    private Reservation getReservationOrThrow(UUID reservationId) {
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> CustomException.from(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+
+    // userId, flightInfo, Redis passengers 기반 티켓 리스트 생성
+    private List<Ticket> createTicketsFromHoldData(UUID userId, GetFlightInfo flightInfo, List<PassengerDto> passengers) {
+
+        List<Ticket> tickets = new ArrayList<>();
+
+        for (PassengerDto p : passengers) {
+            Passenger passenger = Passenger.createPassenger(
+                    userId,
+                    p.name(),
+                    p.birth(),
+                    p.gender(),
+                    p.passportNumber()
+            );
+
+            Ticket ticket = Ticket.createTicket(
+                    passenger,
+                    flightInfo.id(),
+                    userId,
+                    SeatClass.ECONOMY,
+                    flightInfo.price(),
+                    flightInfo.departureDate(),
+                    flightInfo.arrivalDate()
+            );
+
+            tickets.add(ticket);
+        }
+        return tickets;
+    }
+
+
+
+
+    // 결제 요청
+    public PaymentInfo requestPayment(Reservation reservation) {
+
+        // 결제 가능 상태 검증
+        if (!reservation.isPayable()) {
+            throw new CustomException(ReservationErrorCode.PAYMENT_NOT_ALLOWED);
+        }
+
+        // 결제 요청
+        try {
+            return paymentClient.confirmPayment(
+                    reservation.getId(),
+                    reservation.getTotalPrice()
+            );
+
+        } catch (Exception e) {
+            log.error("결제 예외 발생 - ReservationId: {}", reservation.getId(), e);
+            return null;
+        }
+    }
+
+
+
+
+
+    // === 검증 메서드 === //
+    // 예약 내에서 특정 티켓 조회 및 존재 여부 검증
+    // 중복 임시 예약 생성 검증
+    private void validateDuplicateHoldReservation(String key) {
+        if (redisTemplate.hasKey(key)) {
+            throw CustomException.from(ReservationErrorCode.RESERVATION_DUPLICATE);
+        }
+    }
+
+
+    // Redis에서 임시 예약 조회 및 검증
+    private HoldReservationData validateAndGetHoldReservation(String key) {
+
+        String value = redisTemplate.opsForValue().get(key);
+        if (value == null) {
+            throw new CustomException(ReservationErrorCode.HOLD_RESERVATION_EXPIRED);
+        }
+
+        try {
+            return objectMapper.readValue(value, HoldReservationData.class);
+        } catch (JsonProcessingException e) {
+            log.error("Redis 데이터 역직렬화 실패: {}", e.getMessage(), e);
+            throw new CustomException(ReservationErrorCode.REDIS_LOAD_FAILED);
+        }
+    }
+}

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/KafkaReservationProducer.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/KafkaReservationProducer.java
@@ -23,7 +23,6 @@ public class KafkaReservationProducer {
         ReservationCanceledEvent event = ReservationCanceledEvent.of(
                 reservationId,
                 flightId,
-                userId,
                 seatCount,
                 "reservation-canceled");
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/ReservationHeldEventConsumer.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/infrastructure/kafka/ReservationHeldEventConsumer.java
@@ -35,7 +35,7 @@ public class ReservationHeldEventConsumer {
             );
 
             // 예약 임시 생성(사용자가 추후 예약정보 입력하여 예약 완료)
-            reservationService.createHoldReservationV2(command);
+            reservationService.createHoldReservation(command);
 
         } catch (FeignException e) {
             log.error("항공편 조회 실패 - flightId={}, error={}", event.getData().getFlightId(), e.getMessage());

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationController.java
@@ -1,16 +1,13 @@
 package com.oneul_tanda.reservation_service.reservation.presentation;
 
-import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommand;
-import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV1;
 import com.oneul_tanda.reservation_service.reservation.application.command.CreateReservationCommand;
 import com.oneul_tanda.reservation_service.reservation.application.service.ReservationService;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.DeleteReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.create.CreateReservationRequestDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDto;
-import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDtoV2;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.create.CreateReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
-import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDtoV2;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
 import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.read.ReadReservationResponseDto;
 import jakarta.validation.Valid;
@@ -57,20 +54,9 @@ public class ReservationController {
             @RequestHeader("X-User-ID") UUID userId,
             @PathVariable UUID reservationId,
             @RequestBody @Valid ConfirmReservationRequestDto requestDto) {
-        return ResponseEntity.ok(reservationService.confirmReservation(ConfirmReservationCommand.of(userId, reservationId, requestDto)));
+        return ResponseEntity.ok(reservationService.confirmReservation(ConfirmReservationCommandV1.of(userId, reservationId, requestDto)));
     }
 
-
-
-    /**
-     * 예약 확정 v2 (Redis 기반)
-     */
-    @PutMapping("/confirm")
-    public ResponseEntity<ConfirmReservationResponseDto> confirmReservationV2(
-            @RequestHeader("X-User-ID") UUID userId,
-            @RequestBody @Valid ConfirmReservationRequestDtoV2 requestDto) {
-        return ResponseEntity.ok(reservationService.confirmReservationV2(ConfirmReservationCommandV2.of(userId, requestDto)));
-    }
 
 
     /**
@@ -99,16 +85,6 @@ public class ReservationController {
     @PutMapping("/{reservationId}/cancel")
     public ResponseEntity<CancelReservationResponseDto> cancelReservation(@PathVariable UUID reservationId) {
         return ResponseEntity.ok(reservationService.cancelReservation(reservationId));
-    }
-
-
-
-    /**
-     * 예약 취소 V2
-     */
-    @PutMapping("/{reservationId}/cancelV2")
-    public ResponseEntity<CancelReservationResponseDtoV2> cancelReservationV2(@PathVariable UUID reservationId) {
-        return ResponseEntity.ok(reservationService.cancelReservationV2(reservationId));
     }
 
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationControllerV2.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationControllerV2.java
@@ -27,7 +27,6 @@ public class ReservationControllerV2 {
     public ResponseEntity<ConfirmReservationResponseDto> confirmReservationV2(
             @RequestHeader("X-User-Id") UUID userId,
             @RequestBody @Valid ConfirmReservationRequestDtoV2 requestDto) {
-        System.out.println("requestDto: " + requestDto);
         return ResponseEntity.ok(reservationService.confirmReservation(ConfirmReservationCommandV2.of(userId, requestDto)));
     }
 

--- a/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationControllerV2.java
+++ b/reservation-service/src/main/java/com/oneul_tanda/reservation_service/reservation/presentation/ReservationControllerV2.java
@@ -1,0 +1,44 @@
+package com.oneul_tanda.reservation_service.reservation.presentation;
+
+import com.oneul_tanda.reservation_service.reservation.application.command.ConfirmReservationCommandV2;
+import com.oneul_tanda.reservation_service.reservation.application.service.ReservationService;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.request.update.ConfirmReservationRequestDtoV2;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.CancelReservationResponseDto;
+import com.oneul_tanda.reservation_service.reservation.presentation.dto.response.update.ConfirmReservationResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/reservations")
+@RequiredArgsConstructor
+public class ReservationControllerV2 {
+
+    private final ReservationService reservationService;
+
+
+    /**
+     * 예약 확정 v2 (Redis 기반)
+     */
+    @PutMapping("/confirmV2")
+    public ResponseEntity<ConfirmReservationResponseDto> confirmReservationV2(
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestBody @Valid ConfirmReservationRequestDtoV2 requestDto) {
+        System.out.println("requestDto: " + requestDto);
+        return ResponseEntity.ok(reservationService.confirmReservation(ConfirmReservationCommandV2.of(userId, requestDto)));
+    }
+
+
+
+    /**
+     * 예약 취소 V2
+     */
+    @PutMapping("/{reservationId}/cancelV2")
+    public ResponseEntity<CancelReservationResponseDto> cancelReservationV2(@PathVariable UUID reservationId) {
+        return ResponseEntity.ok(reservationService.cancelReservation(reservationId));
+    }
+
+}

--- a/reservation-service/src/test/http/reservation-service.http
+++ b/reservation-service/src/test/http/reservation-service.http
@@ -154,13 +154,6 @@ Authorization: Bearer {{access_token}}
 
 
 
-### 예약 취소 V2
-PUT http://localhost:19091/api/v1/reservations/fb05d396-811b-4fda-a127-30ac61027aaf/cancelV2
-Content-Type: application/json
-Authorization: Bearer {{access_token}}
-
-
-
 ### 예약 삭제
 DELETE http://localhost:19091/api/v1/reservations/b9f9c07b-0b9a-4166-8ffe-5f0673ffe9f0
 Content-Type: application/json

--- a/reservation-service/src/test/http/reservation-service.http
+++ b/reservation-service/src/test/http/reservation-service.http
@@ -147,8 +147,8 @@ Authorization: Bearer {{access_token}}
 
 
 
-### 예약 취소(예약 수정)
-PUT http://localhost:19091/api/v1/reservations/791f1aa3-f2b1-4d08-bbf7-cb236090e30d/cancel
+### 예약 취소 V2
+PUT http://localhost:19091/api/v1/reservations/1c7204d2-c276-4d8e-8c9e-2446423deee4/cancelV2
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 


### PR DESCRIPTION
## 💡 이슈
resolve #{121}

## 🤩 개요
-기존 예약 컨트롤러나 서비스에서 V1, V2 로직이 혼재되어 있어, 구조를 전략 패턴 기반으로 리팩토링.
-버전별 Command 구조도 함께 분리하여 확장성과 유지보수성을 개선

## 🧑‍💻 작업 사항
작업한 내용을 적어주세요.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 예약 확정 및 취소 V2 전용 REST API 엔드포인트가 추가되었습니다.
  - 버전별 예약 처리 전략(Strategy) 구조가 도입되었습니다.

- **버그 수정**
  - 통합 테스트 및 HTTP 테스트에서 예약 확정/취소 엔드포인트와 파라미터가 최신화되었습니다.

- **리팩터링**
  - 예약 서비스의 비즈니스 로직이 전략 패턴으로 분리되어 코드 구조가 개선되었습니다.
  - 예약 관련 커맨드 및 예외 코드가 정비되었습니다.

- **문서 및 테스트**
  - V2 예약 취소 관련 테스트 케이스가 추가 및 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->