### PR TITLE
Feat/#117 feat queue service seat decrement refactor

### DIFF
--- a/queue-service/src/main/java/com/sparta/queueservice/application/dto/QueueResponseDto.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/dto/QueueResponseDto.java
@@ -1,6 +1,6 @@
 package com.sparta.queueservice.application.dto;
 
-import com.sparta.queueservice.infrastructure.kafka.event.EventStatusEnum;
+import com.sparta.queueservice.application.service.EventStatusEnum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/queue-service/src/main/java/com/sparta/queueservice/application/service/EventStatusEnum.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/service/EventStatusEnum.java
@@ -1,4 +1,4 @@
-package com.sparta.queueservice.infrastructure.kafka.event;
+package com.sparta.queueservice.application.service;
 
 public enum EventStatusEnum {
     SUCCESS,

--- a/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
@@ -2,9 +2,9 @@ package com.sparta.queueservice.application.service;
 
 import com.sparta.queueservice.application.dto.FlightRequestDto;
 import com.sparta.queueservice.application.dto.QueueResponseDto;
+import com.sparta.queueservice.infrastructure.client.FlightClient;
 import com.sparta.queueservice.infrastructure.client.FlightResponse;
 import com.sparta.queueservice.infrastructure.kafka.ProducerService;
-import com.sparta.queueservice.infrastructure.client.FlightClient;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
@@ -13,7 +13,6 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 

--- a/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
@@ -125,6 +125,7 @@ public class QueueService {
 //                redisTemplate.opsForValue().set("seat:" + flightId, String.valueOf(remainingSeats));
                 // 실제 항공편 서비스 좌석 차감
                 flightClient.decreaseSeats(flightId, seatCount);
+//                producerService.sendDecreaseSeats(flightId, userId, seatCount);
                 log.info("대기열 선점에 성공 했습니다. 남은 좌석 수: {}", remainingSeats - seatCount);
                 rankOps.remove(key, topUser);
                 producerService.sendReserveSuccess(flightId, userId, seatCount);
@@ -135,7 +136,6 @@ public class QueueService {
                 deleteExistReserve(flightId, userId);
                 return QueueResponseDto.of(EventStatusEnum.FAILED, "남은 좌석이 없습니다.");
             }
-//        return QueueResponseDto.of(EventStatusEnum.FAILED, "예약 신청에 실패하셨습니다.");
     }
 
     // 중복 유저가 있는지 체크

--- a/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueService.java
@@ -4,7 +4,6 @@ import com.sparta.queueservice.application.dto.FlightRequestDto;
 import com.sparta.queueservice.application.dto.QueueResponseDto;
 import com.sparta.queueservice.infrastructure.client.FlightResponse;
 import com.sparta.queueservice.infrastructure.kafka.ProducerService;
-import com.sparta.queueservice.infrastructure.kafka.event.EventStatusEnum;
 import com.sparta.queueservice.infrastructure.client.FlightClient;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -14,7 +13,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Set;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -101,13 +100,17 @@ public class QueueService {
 //        }
 
         // 대기열에 있는 모든 유저 조회
-        Set<String> topUsers = rankOps.range(key, 0, -1);
-        if (topUsers == null || topUsers.isEmpty()) {
+        String topUser = rankOps.range("ranks:" + flightId, 0, 0)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        if (topUser == null || topUser.isEmpty()) {
             return QueueResponseDto.of(EventStatusEnum.FAILED, "대기열에 없는 유저 입니다.");
         }
+
         // 좌석 수가 남아 있을때 대기열 선점 좌석 수가 0이면 실패 메시지를 보낸 후 대기열에서 삭제
-        for(String reserveInfo : topUsers) {
-            String[] parts =  reserveInfo.split(":");
+            String[] parts =  topUser.split(":");
             UUID userId = UUID.fromString(parts[0]);
             int seatCount = Integer.parseInt(parts[1]);
 
@@ -123,17 +126,16 @@ public class QueueService {
                 // 실제 항공편 서비스 좌석 차감
                 flightClient.decreaseSeats(flightId, seatCount);
                 log.info("대기열 선점에 성공 했습니다. 남은 좌석 수: {}", remainingSeats - seatCount);
-                rankOps.remove(key, reserveInfo);
+                rankOps.remove(key, topUser);
                 producerService.sendReserveSuccess(flightId, userId, seatCount);
                 return QueueResponseDto.of(EventStatusEnum.SUCCESS, "대기열 선점에 성공했습니다.");
             } else {
                 log.info("남은 좌석이 없습니다. 남은 좌석 수: {}", remainingSeats);
-                rankOps.remove(key, reserveInfo);
+                rankOps.remove(key, topUser);
                 deleteExistReserve(flightId, userId);
                 return QueueResponseDto.of(EventStatusEnum.FAILED, "남은 좌석이 없습니다.");
             }
-        }
-        return QueueResponseDto.of(EventStatusEnum.FAILED, "예약 신청에 실패하셨습니다.");
+//        return QueueResponseDto.of(EventStatusEnum.FAILED, "예약 신청에 실패하셨습니다.");
     }
 
     // 중복 유저가 있는지 체크

--- a/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueServiceV1.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueServiceV1.java
@@ -18,17 +18,17 @@ import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
-public class QueueService {
+public class QueueServiceV1 {
     private final ZSetOperations<String, String> rankOps;
     private final FlightClient flightClient;
     private final ProducerService producerService;
     private final RedisTemplate<String, String> redisTemplate;
     private final RedissonClient redissonClient;
 
-    public QueueService(FlightClient airportClient,
-                        RedisTemplate<String, String> redisTemplate,
-                        ProducerService producerService,
-                        RedissonClient redissonClient) {
+    public QueueServiceV1(FlightClient airportClient,
+                          RedisTemplate<String, String> redisTemplate,
+                          ProducerService producerService,
+                          RedissonClient redissonClient) {
         this.flightClient = airportClient;
         this.rankOps = redisTemplate.opsForZSet();
         this.producerService = producerService;
@@ -56,7 +56,7 @@ public class QueueService {
         String reserveInfo = userId + ":" + seatCount;
         rankOps.add("ranks:" +  flightId, reserveInfo, score);
 
-       return processReserve(flightId);
+        return processReserve(flightId);
     }
 
     public QueueResponseDto processReserve(UUID flightId) {
@@ -109,32 +109,32 @@ public class QueueService {
         }
 
         // 좌석 수가 남아 있을때 대기열 선점 좌석 수가 0이면 실패 메시지를 보낸 후 대기열에서 삭제
-            String[] parts =  topUser.split(":");
-            UUID userId = UUID.fromString(parts[0]);
-            int seatCount = Integer.parseInt(parts[1]);
+        String[] parts =  topUser.split(":");
+        UUID userId = UUID.fromString(parts[0]);
+        int seatCount = Integer.parseInt(parts[1]);
 
-            if (!isTopUser(userId, flightId)) {
-                log.info("순서가 아닙니다.");
-                return QueueResponseDto.of(EventStatusEnum.FAILED, "순서가 아닙니다.");
-            }
+        if (!isTopUser(userId, flightId)) {
+            log.info("순서가 아닙니다.");
+            return QueueResponseDto.of(EventStatusEnum.FAILED, "순서가 아닙니다.");
+        }
 
-            if(seatCount <= remainingSeats) { // 대기열 선점 성공시 항공편의 좌석 수 차감 후 성공 메세지 전달
-                // 좌석 수 차감 api 필요 (임시 좌석 차감 로직)
+        if(seatCount <= remainingSeats) { // 대기열 선점 성공시 항공편의 좌석 수 차감 후 성공 메세지 전달
+            // 좌석 수 차감 api 필요 (임시 좌석 차감 로직)
 //                remainingSeats -= seatCount;
 //                redisTemplate.opsForValue().set("seat:" + flightId, String.valueOf(remainingSeats));
-                // 실제 항공편 서비스 좌석 차감
-                flightClient.decreaseSeats(flightId, seatCount);
-//                producerService.sendDecreaseSeats(flightId, userId, seatCount);
-                log.info("대기열 선점에 성공 했습니다. 남은 좌석 수: {}", remainingSeats - seatCount);
-                rankOps.remove(key, topUser);
-                producerService.sendReserveSuccess(flightId, userId, seatCount);
-                return QueueResponseDto.of(EventStatusEnum.SUCCESS, "대기열 선점에 성공했습니다.");
-            } else {
-                log.info("남은 좌석이 없습니다. 남은 좌석 수: {}", remainingSeats);
-                rankOps.remove(key, topUser);
-                deleteExistReserve(flightId, userId);
-                return QueueResponseDto.of(EventStatusEnum.FAILED, "남은 좌석이 없습니다.");
-            }
+            // 실제 항공편 서비스 좌석 차감 - v1
+            flightClient.decreaseSeats(flightId, seatCount);
+            log.info("대기열 선점에 성공 했습니다. 남은 좌석 수: {}", remainingSeats - seatCount);
+            rankOps.remove(key, topUser);
+            // v2 로 전환시 주석 처리 해야함
+            producerService.sendReserveSuccess(flightId, userId, seatCount);
+            return QueueResponseDto.of(EventStatusEnum.SUCCESS, "대기열 선점에 성공했습니다.");
+        } else {
+            log.info("남은 좌석이 없습니다. 남은 좌석 수: {}", remainingSeats);
+            rankOps.remove(key, topUser);
+            deleteExistReserve(flightId, userId);
+            return QueueResponseDto.of(EventStatusEnum.FAILED, "남은 좌석이 없습니다.");
+        }
     }
 
     // 중복 유저가 있는지 체크
@@ -162,3 +162,4 @@ public class QueueService {
         return topUser != null && topUser.startsWith(userId.toString());
     }
 }
+

--- a/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueServiceV2.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/application/service/QueueServiceV2.java
@@ -1,0 +1,150 @@
+package com.sparta.queueservice.application.service;
+
+import com.sparta.queueservice.application.dto.FlightRequestDto;
+import com.sparta.queueservice.application.dto.QueueResponseDto;
+import com.sparta.queueservice.infrastructure.client.FlightClient;
+import com.sparta.queueservice.infrastructure.client.FlightResponse;
+import com.sparta.queueservice.infrastructure.kafka.ProducerService;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+public class QueueServiceV2 {
+    private final ZSetOperations<String, String> rankOps;
+    private final FlightClient flightClient;
+    private final ProducerService producerService;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedissonClient redissonClient;
+
+    public QueueServiceV2(FlightClient airportClient,
+                          RedisTemplate<String, String> redisTemplate,
+                          ProducerService producerService,
+                          RedissonClient redissonClient) {
+        this.flightClient = airportClient;
+        this.rankOps = redisTemplate.opsForZSet();
+        this.producerService = producerService;
+        this.redisTemplate = redisTemplate;
+        this.redissonClient = redissonClient;
+    }
+
+    // 예약 신청시 대기열 진입후 대기열 선점
+    public QueueResponseDto tryReserve(FlightRequestDto request, UUID userId) {
+        // 예약 신청한 flightId 와 좌석 수
+        UUID flightId = request.getFlightId();
+        Integer seatCount = request.getSeatCount();
+
+        log.info("예약 요청: flightId={}, seatCount={}, userId={}",
+                request.getFlightId(), request.getSeatCount(), userId);
+        // 중복 예약 체크
+        if(existReserve(flightId, userId)) {
+            log.info("중복된 항공편 입니다. flightId: {} ", flightId);
+            return QueueResponseDto.of(EventStatusEnum.DUPLICATE, "중복된 항공편 입니다.");
+        }
+
+        setExistReserve(flightId, userId);
+        // 대기열에 들어온 순서대로 정렬 (시간순으로 정렬 - 같은 시간을 대비해 난수를 더하기)
+        long score = System.nanoTime() + (long)(Math.random() * 1000);
+        String reserveInfo = userId + ":" + seatCount;
+        rankOps.add("ranks:" +  flightId, reserveInfo, score);
+
+        return processReserve(flightId);
+    }
+
+    public QueueResponseDto processReserve(UUID flightId) {
+        RLock lock = redissonClient.getLock("lock:flight:" + flightId);
+
+        boolean isLocked = false;
+        try {
+            isLocked = lock.tryLock(3, 10, TimeUnit.SECONDS);
+
+            if (isLocked) {
+                return processReserveWithLock(flightId);
+            } else {
+                log.warn("좌석 선점 락 획득 실패: {}", flightId);
+                return QueueResponseDto.of(EventStatusEnum.FAILED, "좌석 락 획득에 실패했습니다.");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return QueueResponseDto.of(EventStatusEnum.FAILED, "스레드 인터셉트가 발생했습니다.");
+        } finally {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    //대기열 진입 후 선점 과정
+    public QueueResponseDto processReserveWithLock(UUID flightId) {
+        String key = "ranks:" +  flightId;
+        // flightId를 받아 좌석 수를 조회
+        FlightResponse flightResponse = flightClient.getFlight(flightId);
+        Integer remainingSeats = flightResponse.getRemainingSeats();
+        // 대기열에 있는 최상위 유저 조회
+        String topUser = rankOps.range("ranks:" + flightId, 0, 0)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        if (topUser == null || topUser.isEmpty()) {
+            return QueueResponseDto.of(EventStatusEnum.FAILED, "대기열에 없는 유저 입니다.");
+        }
+
+        // 좌석 수가 남아 있을때 대기열 선점 좌석 수가 0이면 실패 메시지를 보낸 후 대기열에서 삭제
+        String[] parts =  topUser.split(":");
+        UUID userId = UUID.fromString(parts[0]);
+        int seatCount = Integer.parseInt(parts[1]);
+
+        if (!isTopUser(userId, flightId)) {
+            log.info("순서가 아닙니다.");
+            return QueueResponseDto.of(EventStatusEnum.FAILED, "순서가 아닙니다.");
+        }
+
+        if(seatCount <= remainingSeats) { // 대기열 선점 성공시 항공편의 좌석 수 차감 후 성공 메세지 전달
+            // 좌석 수 차감 api 필요 (임시 좌석 차감 로직)
+            // 항공편 좌석 차감 이벤트 발행  -v2
+            producerService.sendDecreaseSeats(flightId, userId, seatCount);
+            log.info("대기열 선점에 성공 했습니다. 남은 좌석 수: {}", remainingSeats - seatCount);
+            rankOps.remove(key, topUser);
+            return QueueResponseDto.of(EventStatusEnum.SUCCESS, "대기열 선점에 성공했습니다.");
+        } else {
+            log.info("남은 좌석이 없습니다. 남은 좌석 수: {}", remainingSeats);
+            rankOps.remove(key, topUser);
+            deleteExistReserve(flightId, userId);
+            return QueueResponseDto.of(EventStatusEnum.FAILED, "남은 좌석이 없습니다.");
+        }
+    }
+
+    // 중복 유저가 있는지 체크
+    private boolean existReserve(UUID flightId, UUID userId) {
+        String key = "reserve:" +  flightId + ":" + userId;
+        return redisTemplate.hasKey(key);
+    }
+
+    // userId와 flightId를 redis 에 저장해 중복 체크
+    private void setExistReserve(UUID flightId, UUID userId) {
+        String key = "reserve:" +  flightId + ":" + userId;
+        log.info("중복 예약 방지 키: {}", key);
+        redisTemplate.opsForValue().set(key, "1", Duration.ofSeconds(30));
+    }
+
+    // 대기열 선점 실패시 sortedSet 과 같이 삭제
+    public void deleteExistReserve(UUID flightId, UUID userId) {
+        String key = "reserve:" +  flightId + ":" + userId;
+        redisTemplate.delete(key);
+    }
+
+    // 본인이 최상위 유저인지 아닌지 체크
+    private boolean isTopUser(UUID userId, UUID flightId) {
+        String topUser = rankOps.range("ranks:" + flightId, 0, 0).stream().findFirst().orElse(null);
+        return topUser != null && topUser.startsWith(userId.toString());
+    }
+}

--- a/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/ProducerService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/ProducerService.java
@@ -22,10 +22,10 @@ public class ProducerService {
         kafkaTemplate.send("reservation-held", flightId.toString(), event);
     }
 
-//    public void sendDecreaseSeats(UUID flightId, UUID userId, int seatCount) {
-//        ReservationHeldEvent event = ReservationHeldEvent
-//                .createReservationEvent(flightId, userId, seatCount, "flight-decrease");
-//
-//        kafkaTemplate.send("flight-decrease", flightId.toString(), event);
-//    }
+    public void sendDecreaseSeats(UUID flightId, UUID userId, int seatCount) {
+        ReservationHeldEvent event = ReservationHeldEvent
+                .createReservationEvent(flightId, userId, seatCount, "flight-seatReduced");
+
+        kafkaTemplate.send("flight-seatReduced", flightId.toString(), event);
+    }
 }

--- a/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/ProducerService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/ProducerService.java
@@ -1,6 +1,5 @@
 package com.sparta.queueservice.infrastructure.kafka;
 
-import com.sparta.queueservice.infrastructure.kafka.event.EventStatusEnum;
 import com.sparta.queueservice.infrastructure.kafka.event.ReservationHeldEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,5 +20,12 @@ public class ProducerService {
                 .createReservationEvent(flightId, userId, seatCount, "reservation-held");
 
         kafkaTemplate.send("reservation-held", flightId.toString(), event);
+    }
+
+    public void sendDecreaseSeats(UUID flightId, UUID userId, int seatCount) {
+        ReservationHeldEvent event = ReservationHeldEvent
+                .createReservationEvent(flightId, userId, seatCount, "flight-decrease");
+
+        kafkaTemplate.send("flight-decrease", flightId.toString(), event);
     }
 }

--- a/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/ProducerService.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/infrastructure/kafka/ProducerService.java
@@ -22,10 +22,10 @@ public class ProducerService {
         kafkaTemplate.send("reservation-held", flightId.toString(), event);
     }
 
-    public void sendDecreaseSeats(UUID flightId, UUID userId, int seatCount) {
-        ReservationHeldEvent event = ReservationHeldEvent
-                .createReservationEvent(flightId, userId, seatCount, "flight-decrease");
-
-        kafkaTemplate.send("flight-decrease", flightId.toString(), event);
-    }
+//    public void sendDecreaseSeats(UUID flightId, UUID userId, int seatCount) {
+//        ReservationHeldEvent event = ReservationHeldEvent
+//                .createReservationEvent(flightId, userId, seatCount, "flight-decrease");
+//
+//        kafkaTemplate.send("flight-decrease", flightId.toString(), event);
+//    }
 }

--- a/queue-service/src/main/java/com/sparta/queueservice/web/QueueController.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/web/QueueController.java
@@ -2,7 +2,8 @@ package com.sparta.queueservice.web;
 
 import com.sparta.queueservice.application.dto.FlightRequestDto;
 import com.sparta.queueservice.application.dto.QueueResponseDto;
-import com.sparta.queueservice.application.service.QueueService;
+import com.sparta.queueservice.application.service.QueueServiceV1;
+import com.sparta.queueservice.application.service.QueueServiceV2;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,17 +12,28 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/v1/queue")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class QueueController {
-    private final QueueService queueService;
+    private final QueueServiceV1 queueServiceV1;
+    private final QueueServiceV2 queueServiceV2;
 
-    @PostMapping
-    public ResponseEntity<QueueResponseDto> tryReserve(@RequestBody FlightRequestDto request,
+    @PostMapping("/v1/queue")
+    public ResponseEntity<QueueResponseDto> tryReserveV1(@RequestBody FlightRequestDto request,
                                      @RequestHeader("X-User-ID") UUID userId) {
 
-        QueueResponseDto response = queueService.tryReserve(request, userId);
+        QueueResponseDto response = queueServiceV1.tryReserve(request, userId);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    @PostMapping("/v2/queue")
+    public ResponseEntity<QueueResponseDto> tryReserveV2(@RequestBody FlightRequestDto request,
+                                                         @RequestHeader("X-User-ID") UUID userId) {
+
+        QueueResponseDto response = queueServiceV2.tryReserve(request, userId);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
 }

--- a/queue-service/src/main/java/com/sparta/queueservice/web/QueueController.java
+++ b/queue-service/src/main/java/com/sparta/queueservice/web/QueueController.java
@@ -3,7 +3,6 @@ package com.sparta.queueservice.web;
 import com.sparta.queueservice.application.dto.FlightRequestDto;
 import com.sparta.queueservice.application.dto.QueueResponseDto;
 import com.sparta.queueservice.application.service.QueueService;
-import com.sparta.queueservice.infrastructure.kafka.event.EventStatusEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
## 💡 이슈
resolve #117

## 🤩 개요
api 호출기반의 동기 처리 로직을 kafka 기반 비동기 처리로 전환

## 🧑‍💻 작업 사항
예약 서비스로 예약 신청 성공 메세지를 보내는 부분을 v1 으로 두고, v2 버전에서는 좌석 차감 요청 메세지만 보내고 있습니다.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 새로운 예약 큐 서비스(v2) API가 추가되어, `/api/v2/queue` 엔드포인트를 통해 개선된 예약 처리 방식을 제공합니다.
    - 좌석 감소 이벤트 전송 기능이 추가되었습니다.

- **Refactor**
    - 기존 예약 큐 서비스가 `/api/v1/queue`로 버전 분리되어, v1과 v2를 명확히 구분할 수 있습니다.
    - API 엔드포인트가 통합되어 `/api` 하위로 변경되었습니다.

- **Bug Fixes**
    - 중복 예약 방지 및 큐 내 사용자 처리 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->