### PR TITLE
Feat/#129 flight-service redisson 분산 락 적용 및 동시성 제어 테스트

### DIFF
--- a/flight-service/build.gradle
+++ b/flight-service/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// redisson
+	implementation 'org.redisson:redisson-spring-boot-starter:3.23.2'
+
 	// spring cache
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 

--- a/flight-service/build.gradle
+++ b/flight-service/build.gradle
@@ -1,115 +1,115 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 ext {
-	springCloudVersion = "2024.0.1"
-	queryDslVersion = "5.1.0" // QueryDSL 최신 버전
+    springCloudVersion = "2024.0.1"
+    queryDslVersion = "5.1.0" // QueryDSL 최신 버전
 }
 
 group = 'com.oneul-tanda'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	// Amadeus
-	implementation 'com.amadeus:amadeus-java:5.0.0'
+    // Amadeus
+    implementation 'com.amadeus:amadeus-java:5.0.0'
 
-	// redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	// redisson
-	implementation 'org.redisson:redisson-spring-boot-starter:3.23.2'
+    // redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.36.0'
 
-	// spring cache
-	implementation 'org.springframework.boot:spring-boot-starter-cache'
+    // spring cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
-	// spring cloud
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    // spring cloud
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
-	// json serialization & deserialization
-	implementation 'com.fasterxml.jackson.core:jackson-databind'
-	implementation 'com.fasterxml.jackson.core:jackson-core'
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    // json serialization & deserialization
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
-	// QueryDSL
-	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
-	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
-	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
-	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 
-	// jpa
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// interval과 duration을 매핑하기 위한 의존성
-	implementation("com.vladmihalcea:hibernate-types-60:2.21.1")
+    // interval과 duration을 매핑하기 위한 의존성
+    implementation 'com.vladmihalcea:hibernate-types-60:2.21.1'
 
-	// postgresql
-	runtimeOnly 'org.postgresql:postgresql'
+    // postgresql
+    runtimeOnly 'org.postgresql:postgresql'
 
-	// kafka
-	implementation 'org.springframework.kafka:spring-kafka'
-	testImplementation 'org.springframework.kafka:spring-kafka-test'
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
-	// web
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    // web
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// monitoring
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.micrometer:micrometer-registry-prometheus'
+    // monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 // QueryDsl
 def querydslSrcDir = 'src/main/generated'
 
 clean {
-	delete file(querydslSrcDir)
+    delete file(querydslSrcDir)
 }
 
 tasks.withType(JavaCompile) {
-	options.generatedSourceOutputDirectory = file(querydslSrcDir)
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }
 
 sourceSets {
-	main {
-		java {
-			srcDir querydslSrcDir
-		}
-	}
+    main {
+        java {
+            srcDir querydslSrcDir
+        }
+    }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightService.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/application/service/flight/FlightService.java
@@ -8,14 +8,15 @@ import com.oneul_tanda.flight_service.domain.entity.AirportEntity;
 import com.oneul_tanda.flight_service.domain.entity.FlightEntity;
 import com.oneul_tanda.flight_service.domain.exception.airline.AirlineNotFoundException;
 import com.oneul_tanda.flight_service.domain.exception.airport.AirportNotFoundException;
-import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
 import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+import com.oneul_tanda.flight_service.domain.exception.common.GlobalException;
 import com.oneul_tanda.flight_service.domain.exception.flight.FlightDuplicatedException;
 import com.oneul_tanda.flight_service.domain.exception.flight.FlightNotFoundException;
 import com.oneul_tanda.flight_service.domain.repository.airline.AirlineRepository;
 import com.oneul_tanda.flight_service.domain.repository.airport.AirportRepository;
 import com.oneul_tanda.flight_service.domain.repository.flight.FlightRepository;
 import com.oneul_tanda.flight_service.domain.repository.flight.FlightRepositoryCustom;
+import com.oneul_tanda.flight_service.infrastructure.config.redis.lock.DistributedLock;
 import com.oneul_tanda.flight_service.presentation.dtos.flight.FlightDetailResponse;
 import com.oneul_tanda.flight_service.presentation.dtos.flight.FlightResponse;
 import com.oneul_tanda.flight_service.util.PagingUtil;
@@ -33,7 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class FlightService {
 
     private final FlightRepository flightRepository;
@@ -43,6 +43,7 @@ public class FlightService {
     private final FlightEventKafkaProducer flightEventKafkaProducer;
 
     @Cacheable(value = "flights", key = "#flightId")
+    @Transactional(readOnly = true)
     public FlightDetailResponse getFlight(UUID flightId) {
 
         FlightEntity flight = getFlightById(flightId);
@@ -50,6 +51,7 @@ public class FlightService {
         return FlightDetailResponse.from(flight);
     }
 
+    @Transactional(readOnly = true)
     public Page<FlightResponse> searchFlights(String departureAirport, String arrivalAirport,
                                               LocalDateTime departureDate, Integer requiredSeats,
                                               Pageable pageable, String userRole
@@ -136,7 +138,7 @@ public class FlightService {
         flight.updateDeletionInfo(userId);
     }
 
-    @Transactional
+    @DistributedLock(key = "#flightId.toString()")
     @CacheEvict(value = "flights", key = "#flightId") // 캐시 무효화
     public void decreaseSeats(UUID flightId, Integer requiredSeats) {
         FlightEntity flight = getFlightById(flightId);
@@ -144,7 +146,7 @@ public class FlightService {
         flight.decreaseSeatCount(requiredSeats);
     }
 
-    @Transactional
+    @DistributedLock(key = "#flightId.toString()")
     @CacheEvict(value = "flights", key = "#flightId") // 캐시 무효화
     public void increaseSeats(UUID flightId, Integer requiredSeats) {
         FlightEntity flight = getFlightById(flightId);
@@ -153,7 +155,7 @@ public class FlightService {
     }
 
     // 예약 취소(결제 취소)시 좌석 복구 비동기 처리
-    @Transactional
+    @DistributedLock(key = "#flightId.toString()")
     @CacheEvict(value = "flights", key = "#flightId") // 캐시 무효화
     public void increaseSeatsV2(UUID reservationId, UUID flightId, Integer requiredSeats) {
         FlightEntity flight = getFlightById(flightId);

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/ErrorMessage.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/common/ErrorMessage.java
@@ -18,6 +18,9 @@ public enum ErrorMessage {
     FLIGHT_NOT_FOUND("FLIGHT_NOT_FOUND", "해당 항공편을 찾을 수 없습니다."),
     DUPLICATED_FLIGHT("DUPLICATED_FLIGHT", "중복된 항공편입니다."),
 
+    // DistributedLock
+    LOCK_FAILED_AFTER_RETRY("LOCK_FAILED_AFTER_RETRY", "[DistributedLock]: Lock failed after retry"),
+
     // Common
     ACCESS_DENIED("ACCESS_DENIED", "접근 권한이 없습니다."),
     INVALID_REQUEST("INVALID_REQUEST", "잘못된 요청입니다."),

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/lock/LockFailedAfterRetryException.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/domain/exception/lock/LockFailedAfterRetryException.java
@@ -1,0 +1,7 @@
+package com.oneul_tanda.flight_service.domain.exception.lock;
+
+import com.oneul_tanda.flight_service.domain.exception.common.ErrorMessage;
+
+public class LockFailedAfterRetryException extends RuntimeException {
+    public LockFailedAfterRetryException() {super(ErrorMessage.LOCK_FAILED_AFTER_RETRY.getMessage());}
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/amadeus/AmadeusConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/amadeus/AmadeusConfig.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.infrastructure.config;
+package com.oneul_tanda.flight_service.infrastructure.config.amadeus;
 
 import com.amadeus.Amadeus;
 import org.springframework.beans.factory.annotation.Value;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/jpa/JpaAuditorAware.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/jpa/JpaAuditorAware.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.infrastructure.config;
+package com.oneul_tanda.flight_service.infrastructure.config.jpa;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/jpa/JpaConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/jpa/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.infrastructure.config;
+package com.oneul_tanda.flight_service.infrastructure.config.jpa;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/kafka/KafkaConsumerConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/kafka/KafkaConsumerConfig.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.infrastructure.config;
+package com.oneul_tanda.flight_service.infrastructure.config.kafka;
 
 import com.oneul_tanda.flight_service.application.dtos.event.ReservationCanceledEvent;
 import java.util.HashMap;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/kafka/KafkaProducerConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/kafka/KafkaProducerConfig.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.infrastructure.config;
+package com.oneul_tanda.flight_service.infrastructure.config.kafka;
 
 import com.oneul_tanda.flight_service.application.dtos.event.ReservationCanceledEvent;
 import java.util.HashMap;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/querydsl/QueryDslConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/querydsl/QueryDslConfig.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.infrastructure.config;
+package com.oneul_tanda.flight_service.infrastructure.config.querydsl;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/CacheConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/CacheConfig.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.infrastructure.config;
+package com.oneul_tanda.flight_service.infrastructure.config.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneul_tanda.flight_service.presentation.dtos.airline.AirlineResponse;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/JacksonConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/JacksonConfig.java
@@ -1,4 +1,4 @@
-package com.oneul_tanda.flight_service.infrastructure.config;
+package com.oneul_tanda.flight_service.infrastructure.config.redis;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/RedissonConfig.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/RedissonConfig.java
@@ -1,0 +1,27 @@
+package com.oneul_tanda.flight_service.infrastructure.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private String redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/AopForTransaction.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/AopForTransaction.java
@@ -1,0 +1,14 @@
+package com.oneul_tanda.flight_service.infrastructure.config.redis.lock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/CustomSpringELParser.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/CustomSpringELParser.java
@@ -1,0 +1,25 @@
+package com.oneul_tanda.flight_service.infrastructure.config.redis.lock;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(
+            String[] parameterNames,
+            Object[] args,
+            String key
+    ) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+        return parser
+                .parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/DistributedLock.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/DistributedLock.java
@@ -1,0 +1,23 @@
+package com.oneul_tanda.flight_service.infrastructure.config.redis.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 3L;
+
+    long retryDelay() default 3L; // 재시도 사이의 대기 시간
+
+    long maxRetryCount() default 5L; // 최대 재시도 횟수
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/DistributedLockAop.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/DistributedLockAop.java
@@ -1,0 +1,69 @@
+package com.oneul_tanda.flight_service.infrastructure.config.redis.lock;
+
+import com.oneul_tanda.flight_service.domain.exception.lock.LockFailedAfterRetryException;
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAop {
+
+    private static final String REDISSON_LOCK_PREFIX = "LOCK: ";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(com.oneul_tanda.flight_service.infrastructure.config.redis.lock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(
+                signature.getParameterNames(),
+                joinPoint.getArgs(),
+                distributedLock.key());
+
+        RLock rLock = redissonClient.getLock(key);
+
+        // 예외 처리 및 락 획득을 재시도하는 로직
+        int retryCount = 0;
+
+        while (retryCount < distributedLock.maxRetryCount()) {
+            try {
+                boolean available = rLock.tryLock(distributedLock.waitTime(),
+                        distributedLock.leaseTime(), distributedLock.timeUnit());
+
+                if (available) {
+                    log.info("[DistributedLock]: Lock acquired with key: {}", key);
+                    try {
+                        return aopForTransaction.proceed(joinPoint);
+                    } finally {
+                        if (rLock.isLocked() && rLock.isHeldByCurrentThread()) {
+                            log.info("[DistributedLock]: Lock released with key: {}", key);
+                            rLock.unlock();
+                        }
+                    }
+                } else {
+                    log.info("[DistributedLock]: Lock acquisition failed with key: {}", key);
+                    retryCount++;
+                    Thread.sleep(distributedLock.retryDelay());
+                }
+            } catch (InterruptedException e) {
+                log.error("[DistributedLock]: Lock interrupted");
+                throw new InterruptedException(e.getMessage());
+            }
+        }
+        throw new LockFailedAfterRetryException();
+    }
+}

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/DistributedLockAop.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/infrastructure/config/redis/lock/DistributedLockAop.java
@@ -60,10 +60,12 @@ public class DistributedLockAop {
                     Thread.sleep(distributedLock.retryDelay());
                 }
             } catch (InterruptedException e) {
-                log.error("[DistributedLock]: Lock interrupted");
-                throw new InterruptedException(e.getMessage());
+                log.error("[DistributedLock]: Lock interrupted", e);
+                Thread.currentThread().interrupt();
+                throw e;
             }
         }
+        log.warn("[DistributedLock]: Lock acquisition failed after {} retries with key: {}", retryCount, key);
         throw new LockFailedAfterRetryException();
     }
 }

--- a/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/exception/GlobalExceptionHandler.java
+++ b/flight-service/src/main/java/com/oneul_tanda/flight_service/presentation/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.oneul_tanda.flight_service.presentation.exception;
 
+import com.oneul_tanda.flight_service.domain.exception.lock.LockFailedAfterRetryException;
 import com.oneul_tanda.flight_service.domain.exception.airline.AirlineDuplicatedException;
 import com.oneul_tanda.flight_service.domain.exception.airline.AirlineNotFoundException;
 import com.oneul_tanda.flight_service.domain.exception.airport.AirportDuplicatedException;
@@ -63,6 +64,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(FlightDuplicatedException.class)
     public ResponseEntity<ErrorResponse> handleFlightDuplicatedException(FlightDuplicatedException e) {
         return ErrorResponse.createResponse(HttpStatus.CONFLICT, ErrorMessage.DUPLICATED_FLIGHT);
+    }
+
+    // DistributedLock
+    @ExceptionHandler(LockFailedAfterRetryException.class)
+    public ResponseEntity<ErrorResponse> handleLockFailedAfterRetryException(
+            LockFailedAfterRetryException e) {
+        return ErrorResponse.createResponse(HttpStatus.REQUEST_TIMEOUT,
+                ErrorMessage.LOCK_FAILED_AFTER_RETRY);
     }
 
     // Common

--- a/flight-service/src/test/resources/application-test.yml
+++ b/flight-service/src/test/resources/application-test.yml
@@ -1,5 +1,5 @@
 server:
-  port: 19094
+  port: 0
 
 spring:
   application:
@@ -7,22 +7,36 @@ spring:
 
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/flight_db
+    url: jdbc:postgresql://localhost:5436/test_db
     username: admin
     password: 1234
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
         show_sql: true
+    open-in-view: false
 
   data:
     redis:
       host: localhost
       port: 6379
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      auto-offset-reset: earliest
+      group-id: test-group
+      enable-auto-commit: false
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    properties:
+      enable.idempotence: false
+    enabled: false
 
 amadeus:
   base-url: https://test.api.amadeus.com
@@ -31,12 +45,9 @@ amadeus:
 
 eureka:
   client:
-    service-url:
-      defaultZone: http://localhost:19090/eureka/
+    enabled: false
 
 logging:
   level:
-    org:
-      hibernate:
-        SQL: debug
-        type: trace
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
         - id: flight-service
           uri: lb://flight-service
           predicates:
-            - Path=/api/v1/airlines/**, /api/v1/airports/**, /api/v1/flights/**, /api/v1/amadeus/**
+            - Path=/api/v1/airlines/**, /api/v1/airports/**, /api/v1/flights/**, /api/v1/amadeus/**, /internal/v1/flights/**
         # amadeus의 경우에는 internal로 추정
         - id: queue-service
           uri: lb://queue-service

--- a/k6/decreaseSeats.test.js
+++ b/k6/decreaseSeats.test.js
@@ -6,7 +6,7 @@ export let options = {
     duration: '10s',
 };
 
-const token = 'Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJ0b2tlblZlcnNpb24iOjEsImlkIjoiYjNhODkyYTctYWJiZS00NmViLTgxZjItNmVhNDIxY2U4ZDMyIiwicm9sZSI6IkFETUlOIiwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDgzNjc2OTksImV4cCI6MTc0ODM2OTQ5OX0.PnqbCywAwBP8N1E3UZElBTZ6OQuInlasMP6VR0QwuRM'; // 반드시 갱신 필요
+const token = 'Bearer '; // token 입력 필요
 const flightId = '2129373a-1741-45a4-a2b0-56914adcc906';
 
 export default function () {

--- a/k6/decreaseSeats.test.js
+++ b/k6/decreaseSeats.test.js
@@ -1,0 +1,28 @@
+import http from 'k6/http';
+import { check, fail } from 'k6';
+
+export let options = {
+    vus: 100,
+    duration: '10s',
+};
+
+const token = 'Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJ0b2tlblZlcnNpb24iOjEsImlkIjoiYjNhODkyYTctYWJiZS00NmViLTgxZjItNmVhNDIxY2U4ZDMyIiwicm9sZSI6IkFETUlOIiwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDgzNjc2OTksImV4cCI6MTc0ODM2OTQ5OX0.PnqbCywAwBP8N1E3UZElBTZ6OQuInlasMP6VR0QwuRM'; // 반드시 갱신 필요
+const flightId = '2129373a-1741-45a4-a2b0-56914adcc906';
+
+export default function () {
+    const url = `http://localhost:19091/internal/v1/flights/${flightId}/seats/decrease?requiredSeats=1`;
+
+    const headers = {
+        Authorization: token,
+    };
+
+    let res = http.put(url, null, { headers });
+
+    const success = check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+
+    if (!success) {
+        console.error(`❌ 요청 실패 | 상태코드: ${res.status} | 응답: ${res.body}`);
+    }
+}

--- a/k6/increaseSeats.test.js
+++ b/k6/increaseSeats.test.js
@@ -1,0 +1,28 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+    vus: 100,
+    duration: '10s',
+};
+
+const token = 'Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQURNSU4iLCJpZCI6ImIzYTg5MmE3LWFiYmUtNDZlYi04MWYyLTZlYTQyMWNlOGQzMiIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDg1MTAzNTUsImV4cCI6MTc0ODUxMjE1NX0.XtfYAqs5y-P_QhzgDEjnTfvQO19KdW6yGu3oh60Ox5Y'; // 반드시 갱신 필요
+const flightId = '2129373a-1741-45a4-a2b0-56914adcc906';
+
+export default function () {
+    const url = `http://localhost:19091/internal/v1/flights/${flightId}/seats/increase?requiredSeats=1`;
+
+    const headers = {
+        Authorization: token,
+    };
+
+    let res = http.put(url, null, { headers });
+
+    const success = check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+
+    if (!success) {
+        console.error(`❌ 요청 실패 | 상태코드: ${res.status} | 응답: ${res.body}`);
+    }
+}

--- a/k6/increaseSeats.test.js
+++ b/k6/increaseSeats.test.js
@@ -6,7 +6,7 @@ export let options = {
     duration: '10s',
 };
 
-const token = 'Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0ZXIiLCJyb2xlIjoiQURNSU4iLCJpZCI6ImIzYTg5MmE3LWFiYmUtNDZlYi04MWYyLTZlYTQyMWNlOGQzMiIsInRva2VuVmVyc2lvbiI6MSwiaXNzIjoib25ldWwtdGFuZGEiLCJpYXQiOjE3NDg1MTAzNTUsImV4cCI6MTc0ODUxMjE1NX0.XtfYAqs5y-P_QhzgDEjnTfvQO19KdW6yGu3oh60Ox5Y'; // 반드시 갱신 필요
+const token = 'Bearer '; // token 입력 필요
 const flightId = '2129373a-1741-45a4-a2b0-56914adcc906';
 
 export default function () {


### PR DESCRIPTION
## 💡 이슈
resolve #129 

## 🤩 개요
- 항공편 좌석 수 차감 및 복구 로직에 Redisson을 이용한 AOP 기반 분산 락 적용
- k6를 통한 동시성 제어 테스트

## 🧑‍💻 작업 사항
- 분산 락 적용을 위한 Redisson 의존성 추가
- RedissonConfig 설정
- Redisson을 사용하여 AOP 기반으로 분산 락 구현
- 락 획득 재시도 로직 구현
- 락 획득 재시도 실패시, GlobalExceptionHandler를 통한 예외 처리
- 항공편 좌석 수 차감 및 복구 로직에 분산 락 어노테이션(@DistributedLock)적용
- 분산 락 적용 후, k6를 통한 동시성 제어 테스트 완료

## 📖 참고 사항
- Redisson의 분산 락 사용을 위한 RedissonConfig와 기존 Redis Cache 사용을 위한 CacheConfig는 유지보수가 편하도록 별도로 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 분산 락 기반의 동시성 제어 기능이 항공편 좌석 증감 처리에 적용되었습니다.
  - 분산 락 획득 실패 시 발생하는 새로운 예외 및 에러 메시지가 추가되었습니다.
  - 좌석 증감 API에 대한 k6 부하 테스트 스크립트가 추가되었습니다.

- **버그 수정**
  - 항공편 서비스의 트랜잭션 처리 방식이 읽기/쓰기 메서드별로 세분화되었습니다.

- **구성 변경**
  - 내부 항공편 경로(`/internal/v1/flights/**`)가 게이트웨이 라우팅에 추가되었습니다.
  - 여러 설정 파일의 패키지 구조가 세분화되어 관리가 개선되었습니다.
  - 테스트 및 개발 환경 설정이 일부 변경되었습니다.

- **문서화 및 스타일**
  - 빌드 설정 파일의 코드 정렬 및 들여쓰기가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->